### PR TITLE
Flux bounds

### DIFF
--- a/src/few/utils/mappings.py
+++ b/src/few/utils/mappings.py
@@ -323,7 +323,7 @@ def kerrecceq_forward_map(
 
 
 @njit
-def u_of_p(p, pLSO, dpmin, dpmax, alpha):
+def u_of_p(p, pLSO, dpmin=DELTAPMIN, dpmax=DELTAPMAX, alpha=ALPHA_FLUX):
     return np.abs(
         (np.log(p - pLSO + dpmax - 2 * dpmin) - log(dpmax - dpmin)) / log(2)
     ) ** (alpha)
@@ -409,7 +409,7 @@ def a_of_z(z, amin=AMIN, amax=AMAX):
 
 
 @njit
-def e_of_uwz(u, w, z, beta, esep=ESEP, emax=EMAX):
+def e_of_uwz(u, w, z, beta=BETA_FLUX, esep=ESEP, emax=EMAX):
     return Secc_of_uz(u, z, beta, esep, emax) * w
 
 @njit

--- a/src/few/utils/utility.py
+++ b/src/few/utils/utility.py
@@ -1563,14 +1563,14 @@ def _get_separatrix_kernel_inner(a: float, e: float, x: float, tol: float = 1e-1
         # Schwarzschild
         return 6 + 2 * e
 
-    elif x == 1.0:  # Eccentric Prograde Equatorial
+    elif np.abs(x) == 1.0 and a*x > 0:  # Eccentric Prograde Equatorial
         x_lo = 1.0 + e
         x_hi = 6.0 + 2.0 * e
 
         p_sep = _brentq_jit(_separatrix_polynomial_equat, x_lo, x_hi, (a, e), tol)
         return p_sep
 
-    elif x == -1.0:  # Eccentric Retrograde Equatorial
+    elif np.abs(x) == 1.0 and a*x < 0:  # Eccentric Retrograde Equatorial
         x_lo = 6 + 2.0 * e
         x_hi = 5 + e + 4 * sqrt(1 + e)
 
@@ -1656,24 +1656,24 @@ def get_separatrix(
         import numpy as xp
 
     # determines shape of input
-    if isinstance(e, float):
+    if isinstance(e, float) or isinstance(e, int):
         separatrix = _get_separatrix_kernel_inner(a, e, x, tol=tol)
 
     else:
         e_in = xp.atleast_1d(e)
 
-        if isinstance(x, float):
+        if isinstance(x, float) or isinstance(x, int):
             x_in = xp.full_like(e_in, x)
         else:
             x_in = xp.atleast_1d(x)
 
         # cast spin values if necessary
-        if isinstance(a, float):
+        if isinstance(a, float) or isinstance(a, int):
             a_in = xp.full_like(e_in, a)
         else:
             a_in = xp.atleast_1d(a)
 
-        if isinstance(x, float):
+        if isinstance(x, float) or isinstance(x, int):
             x_in = xp.full_like(e_in, x)
         else:
             x_in = xp.atleast_1d(x)


### PR DESCRIPTION
This branch adds new methods to the `KerrEccEqFlux`, namely:
- `bounds_p(self, e, x=None, a=None)`
- `bounds_e(self, p, x=None, a=None)`
- `min_e(self, p, x=None, a=None)`
- `max_e(self, p, x=None, a=None)`

Additionally, I made some adjustments to address issues in `get_separatrix` that was not returning the expected results for $a<0$ and $e = 0$


<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--4.org.readthedocs.build/en/4/

<!-- readthedocs-preview fastemriwaveforms end -->