### PR TITLE
Feat: change`few_files` behaviour to ignore "deprecated"-tagged files

### DIFF
--- a/src/few/cmd/files.py
+++ b/src/few/cmd/files.py
@@ -31,7 +31,7 @@ def few_files_fetch(args: argparse.Namespace):
                 file_manager.download_dir
             )
         )
-        file_manager.prefetch_all_files()
+        file_manager.prefetch_all_files(discarded_tags=["deprecated"])
     else:
         logger.info(
             "Downloading all missing files tagged '{}' into '{}'\n".format(

--- a/src/few/files/manager.py
+++ b/src/few/files/manager.py
@@ -462,9 +462,24 @@ class FileManager:
             (file.name for file in self._registry.get_files_by_tag(tag))
         )
 
-    def prefetch_all_files(self):
+    def prefetch_all_files(self, discarded_tags: typing.Optional[list[str]] = None):
         """Ensure all files defined in registry are locally present (or raise errors)"""
-        self.prefetch_files_by_list((file.name for file in self._registry.files))
+
+        def keep_file(file: File, discarded_tags: typing.Optional[list[str]] = None):
+            if discarded_tags is None:
+                return True
+            for discarded_tag in discarded_tags:
+                if discarded_tag in file.tags:
+                    return False
+            return True
+
+        self.prefetch_files_by_list(
+            (
+                file.name
+                for file in self._registry.files
+                if keep_file(file, discarded_tags)
+            )
+        )
 
     def open(self, file: os.PathLike, mode="r", **kwargs):
         """Wrapper for open() built-in with automatic file download if needed."""


### PR DESCRIPTION
Now the `few_files fetch` command will download all files expect those having the `deprecated` tag.
These can still be downloaded with `few_files fetch --tag deprecated` if needed.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--12.org.readthedocs.build/en/12/

<!-- readthedocs-preview fastemriwaveforms end -->