### PR TITLE
Add a `few.git_version` module with git metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ cython_debug/
 
 # Version file
 src/*/_version.py
+src/*/git_version.py
 
 # Ignore symlink in editable mode
 src/few/CITATION.cff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,12 +141,14 @@ if(_FEW_WITH_GPU)
   enable_language(CUDA)
   find_package(CUDAToolkit REQUIRED)
 endif()
-unset(_FEW_WITH_GPU)
 
 # ---- Include sources ----
 add_subdirectory(src)
 
 # ---- Let CMake handle copying CITATION.cff into wheel ----
 if(SKBUILD_STATE STREQUAL "sdist" OR SKBUILD_STATE STREQUAL "wheel")
-  install(FILES CITATION.cff DESTINATION few)
+  if(_FEW_WITH_CPU)
+    # A bare install does not need to embed CITATION.cff
+    install(FILES CITATION.cff DESTINATION few)
+  endif()
 endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,8 @@ urls.Homepage = "https://github.com/BlackHolePerturbationToolkit/FastEMRIWavefor
 urls.Source = "https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms"
 urls.Tracker = "https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/issues"
 
-scripts.few_citations = "few.cmd.citations:main"
-scripts.few_files = "few.cmd.files:main"
+scripts.few_citations = "few.cmd.citations:main" #@SKIP_PLUGIN@
+scripts.few_files = "few.cmd.files:main"         #@SKIP_PLUGIN@
 
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ version_file = "src/few/_version.py"
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = [ "src/few/_version.py", "tests/" ]
+sdist.include = [ "src/few/_version.py", "src/few/git_version.py", "tests/" ]
 sdist.exclude = [
   ".devcontainer/",
   ".github/",
@@ -124,6 +124,7 @@ sdist.exclude = [
   "TODO.txt",
   "Tutorial_interpolation.ipynb",
   "src/few/_editable.py",
+  "src/few/git_version.py.in",
 ]
 
 wheel.exclude = [

--- a/src/few/CMakeLists.txt
+++ b/src/few/CMakeLists.txt
@@ -1,2 +1,42 @@
 # Add subdirectories which contain compiled sources
 add_subdirectory(cutils)
+
+# Handle Git Metadata
+message(CHECK_START "Building few.git_version metadata")
+
+message(CHECK_START "Find Git executable")
+find_package(Git)
+if(Git_FOUND)
+  message(CHECK_PASS "found")
+  message(CHECK_START "Checking if in Git worktree")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --is-inside-work-tree
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_QUIET ERROR_QUIET
+    RESULT_VARIABLE FEW_GIT_IN_WORKTREE_CODE)
+  if(FEW_GIT_IN_WORKTREE_CODE EQUAL "0")
+    message(CHECK_PASS "yes")
+
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} log -1 --format=%H
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      OUTPUT_VARIABLE FEW_GIT_COMMIT_ID
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      OUTPUT_VARIABLE FEW_GIT_COMMIT_SHORT_ID
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    configure_file(git_version.py.in git_version.py @ONLY)
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/git_version.py DESTINATION few)
+
+    message(CHECK_PASS "done")
+  else()
+    message(CHECK_FAIL "no")
+  endif()
+else()
+  message(CHECK_FAIL "not found")
+  message(CHECK_FAIL "few.git_version will not be available")
+endif()

--- a/src/few/git_version.py.in
+++ b/src/few/git_version.py.in
@@ -1,0 +1,7 @@
+"""Metadata deduced from git at build time."""
+
+id: str
+short_id: str
+
+id = "@FEW_GIT_COMMIT_ID@"
+short_id = "@FEW_GIT_COMMIT_SHORT_ID@"

--- a/src/few/utils/citations.py
+++ b/src/few/utils/citations.py
@@ -318,20 +318,27 @@ def build_citation_registry() -> CitationRegistry:
     return CitationRegistry(**references, **{cff["title"]: to_reference(cff)})
 
 
-CITATIONS_REGISTRY = build_citation_registry()
-
 COMMON_REFERENCES = [REFERENCE.FEW, REFERENCE.LARGER_FEW, REFERENCE.FEW_SOFTWARE]
 
 
 class Citable:
     """Base class for classes associated with specific citations."""
 
+    registry: Optional[CitationRegistry] = None
+
     @classmethod
     def citation(cls) -> str:
         """Return the module references as a printable BibTeX string."""
         references = cls.module_references()
+
+        if Citable.registry is None:
+            from few import get_logger
+
+            get_logger().debug("Building the Citation Registry from CITATION.cff")
+            Citable.registry = build_citation_registry()
+
         bibtex_entries = [
-            CITATIONS_REGISTRY.get(str(key)).to_bibtex() for key in references
+            Citable.registry.get(str(key)).to_bibtex() for key in references
         ]
         return "\n\n".join(bibtex_entries)
 


### PR DESCRIPTION
This PR comes in response to #31 .

It implements the dynamic generation of a `few.git_version` module at build time.
This module defines, for now, two entries:

- `id`: commit hash id (result of `git log -1 --format=%H`)
- `short_id`: short version of the hash id (result of `git log -1 --format=%h`), often equal to the 7 first characters of the long id (can be longer than that in case of collision between two different commits)

We can easily extend it to more entries if needed (author, commit message, whether we are on a tag or a branch while compiling, ...). See [here](https://git.ligo.org/lscsoft/lalsuite/-/blob/1b18810cce3f39f6516fe3ec72e18c8b57d2e49b/gnuscripts/git_version.py.git) for reference.

Closes #31

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--36.org.readthedocs.build/en/36/

<!-- readthedocs-preview fastemriwaveforms end -->