### PR TITLE
Fix tests, scalar inputs and step size tuner

### DIFF
--- a/src/few/summation/fdinterp.py
+++ b/src/few/summation/fdinterp.py
@@ -158,6 +158,7 @@ class FDInterpolatedModeSum(SummationBase, SchwarzschildEccentric):
         ylms,
         phase_interp_t,
         phase_interp_coeffs,
+        l_arr,
         m_arr,
         n_arr,
         M,
@@ -195,6 +196,7 @@ class FDInterpolatedModeSum(SummationBase, SchwarzschildEccentric):
                 (:math:`\Phi_\phi`).
             Phi_r (1D double self.xp.ndarray): Array of radial phase values
                  (:math:`\Phi_r`).
+            l_arr (1D int self.xp.ndarray): :math:`l` values associated with each mode.
             m_arr (1D int self.xp.ndarray): :math:`m` values associated with each mode.
             n_arr (1D int self.xp.ndarray): :math:`n` values associated with each mode.
             M (double): Total mass in solar masses.
@@ -491,6 +493,10 @@ class FDInterpolatedModeSum(SummationBase, SchwarzschildEccentric):
         phase_interp_coeffs_in = self.xp.transpose(
             self.xp.asarray(phase_interp_coeffs), [2, 1, 0]
         ).flatten()
+
+        # for ylm with negative m, need to multiply by (-1)**l as this is assumed to have happened by the kernel
+        ylms = ylms.copy()
+        ylms[num_teuk_modes:] *= (-1) ** l_arr
 
         # run GPU kernel
         self.get_waveform_fd(

--- a/src/few/utils/utility.py
+++ b/src/few/utils/utility.py
@@ -310,7 +310,7 @@ def ELQ_to_pex(
         Tuple of (OmegaPhi, OmegaTheta, OmegaR). These are 1D arrays or scalar values depending on inputs.
     """
     # check if inputs are scalar or array
-    if isinstance(E, float):
+    if not hasattr(E, '__len__'):
         # get frequencies
         p, e, x = _ELQ_to_pex_kernel_inner(a, E, Lz, Q)
 
@@ -320,7 +320,7 @@ def ELQ_to_pex(
         Q_in = np.atleast_1d(Q)
 
         # cast the spin to the same size array as p
-        if isinstance(a, float):
+        if not hasattr(a, '__len__'):
             a_in = np.full_like(E_in, a)
         else:
             a_in = np.atleast_1d(a)
@@ -681,7 +681,7 @@ def get_fundamental_frequencies(
         import numpy as xp
 
     # check if inputs are scalar or array
-    if isinstance(p, float):
+    if not hasattr(p, '__len__'):
         OmegaPhi, OmegaTheta, OmegaR = _KerrGeoCoordinateFrequencies_kernel_inner(
             a, p, e, x
         )
@@ -691,7 +691,7 @@ def get_fundamental_frequencies(
         x_in = xp.atleast_1d(x)
 
         # cast the spin to the same size array as p
-        if isinstance(a, float):
+        if not hasattr(a, '__len__'):
             a_in = xp.full_like(p_in, a)
         else:
             a_in = xp.atleast_1d(a)
@@ -1048,7 +1048,7 @@ def get_fundamental_frequencies_spin_corrections(
     assert np.all(np.abs(x) == 1.0), "Currently only supported for equatorial orbits."
 
     # check if inputs are scalar or array
-    if isinstance(p, float):
+    if not hasattr(p, '__len__'):
         OmegaPhi, OmegaTheta, OmegaR = _KerrEqSpinFrequenciesCorrections_kernel_inner(
             a, p, e, x
         )
@@ -1058,7 +1058,7 @@ def get_fundamental_frequencies_spin_corrections(
         x_in = np.atleast_1d(x)
 
         # cast the spin to the same size array as p
-        if isinstance(a, float):
+        if not hasattr(a, '__len__'):
             a_in = np.full_like(p_in, a)
         else:
             a_in = np.atleast_1d(a)
@@ -1273,7 +1273,7 @@ def get_kerr_geo_constants_of_motion(
     """
 
     # check if inputs are scalar or array
-    if isinstance(p, float):
+    if not hasattr(p, '__len__'):
         E, L, Q = _KerrGeoConstantsOfMotion_kernel_inner(a, p, e, x)
     else:
         p_in = np.atleast_1d(p)
@@ -1281,7 +1281,7 @@ def get_kerr_geo_constants_of_motion(
         x_in = np.atleast_1d(x)
 
         # cast the spin to the same size array as p
-        if isinstance(a, float):
+        if not hasattr(a, '__len__'):
             a_in = np.full_like(p_in, a)
         else:
             a_in = np.atleast_1d(a)
@@ -1652,7 +1652,7 @@ def get_separatrix(
 
     """
     # determines shape of input
-    if isinstance(e, float) or isinstance(e, int):
+    if not hasattr(e, '__len__'):
         return _get_separatrix_kernel_inner(a, e, x, tol=tol)
 
     if use_gpu:
@@ -1662,21 +1662,16 @@ def get_separatrix(
 
     e_in = xp.atleast_1d(e)
 
-    if isinstance(x, float) or isinstance(x, int):
+    if not hasattr(x, '__len__'):
         x_in = xp.full_like(e_in, x)
     else:
         x_in = xp.atleast_1d(x)
 
     # cast spin values if necessary
-    if isinstance(a, float) or isinstance(a, int):
+    if not hasattr(a, '__len__'):
         a_in = xp.full_like(e_in, a)
     else:
         a_in = xp.atleast_1d(a)
-
-    if isinstance(x, float) or isinstance(x, int):
-        x_in = xp.full_like(e_in, x)
-    else:
-        x_in = xp.atleast_1d(x)
 
     assert len(a_in) == len(e_in) == len(x_in)
 

--- a/tests/test_few.py
+++ b/tests/test_few.py
@@ -180,7 +180,7 @@ def amplitude_test(amp_class):
 
     first_check = np.allclose(specific_teuk_modes[(2, 2, 0)], teuk_modes[:, inds[0]])
     second_check = np.allclose(
-        specific_teuk_modes[(7, -3, 1)], np.conj(teuk_modes[:, inds[1]])
+        specific_teuk_modes[(7, -3, 1)], (-1)**7 * np.conj(teuk_modes[:, inds[1]])
     )
     return first_check, second_check
 


### PR DESCRIPTION
This PR includes the following

- A fix for the amplitude testing that currently exists to properly check negative mode symmetry handling.
- Utility functions now properly handle scalar/array input checking.
- The initial step size tuning is now implemented properly to match the scipy method. It is also not called for `DENSE_STEPPING=1`.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--38.org.readthedocs.build/en/38/

<!-- readthedocs-preview fastemriwaveforms end -->