### PR TITLE
mappings tests and fixes

### DIFF
--- a/src/few/utils/mappings/pn.py
+++ b/src/few/utils/mappings/pn.py
@@ -187,7 +187,7 @@ def _PN_C(q, p, e, Y):
 
 @njit(fastmath=False)
 def _Y_to_xI_kernel_inner(a, p, e, Y):
-    if abs(Y) == 1:
+    if abs(Y) == 1 or Y == 0.0:
         return Y
 
     E = _PN_E(a, p, e, Y)
@@ -206,7 +206,11 @@ def _Y_to_xI_kernel_inner(a, p, e, Y):
 @njit
 def _Y_to_xI_kernel(xI, a, p, e, Y):
     for i in range(len(xI)):
-        xI[i] = _Y_to_xI_kernel_inner(a[i], p[i], e[i], Y[i])
+        Y_h = Y[i]
+        if Y_h != 0.:
+            xI[i] = _Y_to_xI_kernel_inner(a[i], p[i], e[i], Y_h)
+        else:
+            xI[i] = 0.
 
 
 def Y_to_xI(
@@ -237,7 +241,7 @@ def Y_to_xI(
     """
 
     # determines shape of input
-    if isinstance(e, float):
+    if not hasattr(p, "__len__"):
         x = _Y_to_xI_kernel_inner(a, p, e, Y)
     else:
         p_in = np.atleast_1d(p)
@@ -245,7 +249,7 @@ def Y_to_xI(
         Y_in = np.atleast_1d(Y)
 
         # cast spin values if necessary
-        if isinstance(a, float):
+        if not hasattr(a, "__len__"):
             a_in = np.full_like(e_in, a)
         else:
             a_in = np.atleast_1d(a)

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -1,0 +1,76 @@
+import unittest
+
+import numpy as np
+
+from few.utils.mappings.pn import Y_to_xI, xI_to_Y
+from few.utils.mappings.kerrecceq import kerrecceq_forward_map, kerrecceq_backward_map
+from few.utils.utility import get_separatrix
+from few.utils.globals import get_logger, get_first_backend
+
+few_logger = get_logger()
+
+few_logger.warning(
+    "Mappings tests are running"
+)
+
+class MappingsTest(unittest.TestCase):
+    def test_kerrecceq_mapping(self):
+        
+        # test the mapping is invertible
+
+        # regionA
+        a = 0.3
+        p = 8.
+        e = 0.4
+        xI = 1.
+
+        for kind in ["flux", "amplitude"]:
+            u, w, y, z = kerrecceq_forward_map(a, p, e, xI)
+            a_new, p_new, e_new, xI_new = kerrecceq_backward_map(u, w, y, z)
+
+            np.testing.assert_allclose([a, p, e, xI], [a_new.item(), p_new.item(), e_new.item(), xI_new.item()], rtol=1e-10)
+
+        # regionB
+        p = 45.
+        for kind in ["flux", "amplitude"]: 
+            u, w, y, z = kerrecceq_forward_map(a, p, e, xI, kind=kind)
+            a_new, p_new, e_new, xI_new = kerrecceq_backward_map(u, w, y, z, regionA=False, kind=kind)
+            
+            np.testing.assert_allclose([a, p, e, xI], [a_new.item(), p_new.item(), e_new.item(), xI_new.item()], rtol=1e-10)
+
+        # check the mapping at the inner p boundary for NaNs due to logarithmic scaling
+        p = get_separatrix(a, e, xI) + 1e-3
+        u, w, y, z = kerrecceq_forward_map(a, p, e, xI)
+        self.assertFalse(np.isnan(u))
+
+    def test_PN_mapping(self):
+
+        # Check whether Y->xI and xI->Y are inverses
+        a = 0.3
+        p = 8.
+        e = 0.4
+        Y = 0.3
+
+        xI = Y_to_xI(a, p, e, Y)
+        Y_new = xI_to_Y(a, p, e, xI)
+
+        np.testing.assert_allclose(Y_new, Y, rtol=1e-10)
+
+        # check that equatorial maps to equatorial
+        Y = 1.
+
+        xI = Y_to_xI(a, p, e, Y)
+        Y_new = xI_to_Y(a, p, e, xI)
+
+        np.testing.assert_allclose(Y_new, Y, rtol=1e-10)
+        np.testing.assert_allclose(xI, Y, rtol=1e-10)
+
+        # check that polar maps to polar
+        Y = 0.
+        
+        xI = Y_to_xI(a, p, e, Y)
+
+        np.testing.assert_allclose(xI, Y, rtol=1e-10)
+
+        # check integer arguments doesn't break things
+        np.testing.assert_allclose(Y_to_xI(0.3, 8, 0.4, 1), Y_to_xI(0.3, 8., 0.4, 1.), rtol=1e-10)


### PR DESCRIPTION
- Adds tests for the pn and kerrecceq mapping functions, checking they are invertible and don't crash for edge cases
- FIxes the kerrecceq mapping functions such that off-grid values in the negative $w$ and $u$ directions correctly produce negative values (which is important for bounds checking during trajectory evaluation.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--41.org.readthedocs.build/en/41/

<!-- readthedocs-preview fastemriwaveforms end -->