### PR TITLE
Integrator accessibility improvements

### DIFF
--- a/src/few/trajectory/inspiral.py
+++ b/src/few/trajectory/inspiral.py
@@ -124,6 +124,26 @@ class EMRIInspiral(TrajectoryBase):
         return [REFERENCE.KERR_SEPARATRIX] + super().module_references()
 
     @property
+    def npoints(self):
+        """Number of points in the trajectory."""
+        return self.inspiral_generator.npoints
+
+    @property
+    def tolerance(self) -> float:
+        """Absolute tolerance of the integrator."""
+        return self.inspiral_generator.npoints
+    
+    @property
+    def dense_stepping(self) -> bool:
+        """If ``True``, trajectory is using fixed stepping."""
+        return self.inspiral_generator.dense_stepping
+
+    @property
+    def integrate_backwards(self) -> bool:
+        """If ``True``, integrate backwards."""
+        return self.inspiral_generator.integrate_backwards
+
+    @property
     def trajectory(self):
         return self.inspiral_generator.trajectory
 

--- a/src/few/trajectory/integrate.py
+++ b/src/few/trajectory/integrate.py
@@ -416,13 +416,28 @@ class Integrate:
         self.traj_step = 0
 
     @property
+    def tolerance(self) -> float:
+        """Absolute tolerance of the integrator."""
+        return self.dopr.abstol
+    
+    @property
+    def dense_stepping(self) -> bool:
+        """If ``True``, trajectory is using fixed stepping."""
+        return self.dopr.fix_step
+
+    @property
+    def npoints(self) -> int:
+        """Number of points in the trajectory."""
+        return self.traj_step
+
+    @property
     def trajectory(self) -> np.ndarray:
         """Trajectory array."""
         return self.trajectory_arr[: self.traj_step]
 
     @property
     def integrator_t_cache(self) -> np.ndarray:
-        """Time array."""
+        """Spline coefficient time array."""
         return self._integrator_t_cache[: self.traj_step]
 
     @property

--- a/src/few/waveform/base.py
+++ b/src/few/waveform/base.py
@@ -467,32 +467,29 @@ class SphericalHarmonicWaveformBase(
             self.num_modes_kept = teuk_modes_in.shape[1]
 
             # prepare phases for summation modules
-            if not self.inspiral_generator.inspiral_generator.dopr.fix_step:
+            if not self.inspiral_generator.dense_stepping:
                 # prepare phase spline coefficients
-                phase_spline_coeff = self.xp.asarray(
-                    self.inspiral_generator.inspiral_generator.integrator_spline_coeff
-                )  # TODO make these accessible from EMRIInspiral
-
-                # scale coefficients here by the mass ratio
-                phase_information_in = phase_spline_coeff[:, [3, 5], :] / (mu / M)
+                phase_information_in = self.xp.asarray(
+                    self.inspiral_generator.integrator_spline_phase_coeff
+                )[:, [0,2], :]
 
                 # flip azimuthal phase for retrograde inspirals
                 if a > 0:
                     phase_information_in[:, 0] *= self.xp.sign(xI0)
 
-                if self.inspiral_generator.inspiral_generator.integrate_backwards:
+                if self.inspiral_generator.integrate_backwards:
                     phase_information_in[:, :, 0] += self.xp.array(
                         [Phi_phi[-1] + Phi_phi[0], Phi_r[-1] + Phi_r[0]]
                     )
 
                 phase_t_in = (
-                    self.inspiral_generator.inspiral_generator.integrator_t_cache
+                    self.inspiral_generator.integrator_spline_t
                 )
             else:
                 phase_information_in = self.xp.asarray(
                     [Phi_phi_temp, Phi_theta_temp, Phi_r_temp]
                 )
-                if self.inspiral_generator.inspiral_generator.integrate_backwards:
+                if self.inspiral_generator.integrate_backwards:
                     phase_information_in[0] += self.xp.array([Phi_phi[-1] + Phi_phi[0]])
                     phase_information_in[1] += self.xp.array(
                         [Phi_theta[-1] + Phi_theta[0]]
@@ -523,7 +520,7 @@ class SphericalHarmonicWaveformBase(
                 dt=dt,
                 T=T,
                 include_minus_m=include_minus_m,
-                integrate_backwards=self.inspiral_generator.inspiral_generator.integrate_backwards,
+                integrate_backwards=self.inspiral_generator.integrate_backwards,
                 **kwargs,
             )
 
@@ -757,14 +754,14 @@ class AAKWaveformBase(Pn5AAK, ParallelModuleBase, Generic[InspiralModule, SumMod
 
         # prepare phase spline coefficients
         traj_spline_coeff = self.xp.asarray(
-            self.inspiral_generator.inspiral_generator.integrator_spline_coeff
-        )  # TODO make these accessible from EMRIInspiral
+            self.inspiral_generator.integrator_spline_coeff
+        )
 
         # scale coefficients here by the mass ratio
         traj_spline_coeff_in = traj_spline_coeff.copy()
         traj_spline_coeff_in[:, 3:, :] /= mu / M
 
-        if self.inspiral_generator.inspiral_generator.integrate_backwards:
+        if self.inspiral_generator.integrate_backwards:
             traj_spline_coeff_in[:, 3:, 0] += self.xp.array(
                 [
                     Phi_phi[-1] + Phi_phi[0],
@@ -784,12 +781,12 @@ class AAKWaveformBase(Pn5AAK, ParallelModuleBase, Generic[InspiralModule, SumMod
             qK,
             phiK,
             self.nmodes,
-            self.inspiral_generator.inspiral_generator.integrator_t_cache,
+            self.inspiral_generator.integrator_spline_t,
             traj_spline_coeff_in,
             mich=mich,
             dt=dt,
             T=T,
-            integrate_backwards=self.inspiral_generator.inspiral_generator.integrate_backwards,
+            integrate_backwards=self.inspiral_generator.integrate_backwards,
         )
 
         return waveform


### PR DESCRIPTION
Joins up integrator-level properties with `EMRIInspiral` and the waveform generation baseclass a bit better (addresses #40)(

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--46.org.readthedocs.build/en/46/

<!-- readthedocs-preview fastemriwaveforms end -->