### PR TITLE
Enhance mode selection

### DIFF
--- a/src/few/amplitude/ampinterp2d.py
+++ b/src/few/amplitude/ampinterp2d.py
@@ -377,32 +377,32 @@ class AmpInterpKerrEccEq(AmplitudeBase, KerrEccentricEquatorial):
         except AttributeError:
             pass
 
-        a = np.atleast_1d(a)
-        p = np.atleast_1d(p)
-        e = np.atleast_1d(e)
-        xI = np.atleast_1d(xI)
+        a = self.xp.atleast_1d(a)
+        p = self.xp.atleast_1d(p)
+        e = self.xp.atleast_1d(e)
+        xI = self.xp.atleast_1d(xI)
 
         lengths = [len(arr) for arr in (a, p, e, xI)]
         non_one_lengths = {l for l in lengths if l > 1}  # Collect lengths greater than 1
     
         assert len(non_one_lengths) <= 1, f"Arrays must be length one or, if larger, have the same length. Found lengths: {lengths}"
 
-        assert np.all(a*xI <= 0.0) or np.all(
+        assert self.xp.all(a*xI <= 0.0) or self.xp.all(
             a*xI >= 0.0
         )  # either all prograde or all retrograde
-        assert np.all(np.abs(xI) == 1.0) # all equatorial
+        assert self.xp.all(self.xp.abs(xI) == 1.0) # all equatorial
 
         # symmetry of flipping the sign of the spin to keep xI positive
-        if np.all(xI < 0.0):
+        if self.xp.all(xI < 0.0):
             m_mode_sign = -1
         else:
             m_mode_sign = 1
 
-        xI_in = np.ones_like(p) * xI
+        xI_in = self.xp.ones_like(p) * xI
 
         signed_spin = a * xI_in
-        a_in = np.full_like(p, signed_spin)
-        xI_in = np.abs(xI_in)
+        a_in = self.xp.full_like(p, signed_spin)
+        xI_in = self.xp.abs(xI_in)
 
         if specific_modes is not None:
             self.num_modes_eval = len(specific_modes)
@@ -440,7 +440,7 @@ class AmpInterpKerrEccEq(AmplitudeBase, KerrEccentricEquatorial):
         z_check = z[0]
 
         for elem in [u, w, z]:
-            if np.any((elem < 0) | (elem > 1)):
+            if xp.any((elem < 0) | (elem > 1)):
                 raise ValueError("Amplitude interpolant accessed out-of-bounds.")
 
         region_mask = self.xp.asarray(region_mask)
@@ -448,14 +448,14 @@ class AmpInterpKerrEccEq(AmplitudeBase, KerrEccentricEquatorial):
         w = self.xp.asarray(w)
 
         if z_check in self.z_values:
-            ind_1 = np.where(self.z_values == z_check)[0][0]
+            ind_1 = self.xp.where(self.z_values == z_check)[0][0]
 
             Amp_z = self.evaluate_interpolant_at_index(
                 ind_1, region_mask, w, u, mode_indexes=mode_indexes
             )
 
         else:
-            ind_above = np.where(self.z_values > z_check)[0][0]
+            ind_above = self.xp.where(self.z_values > z_check)[0][0]
             ind_below = ind_above - 1
             assert ind_above < len(self.z_values)
             assert ind_below >= 0

--- a/src/few/amplitude/ampinterp2d.py
+++ b/src/few/amplitude/ampinterp2d.py
@@ -446,7 +446,7 @@ class AmpInterpKerrEccEq(AmplitudeBase, KerrEccentricEquatorial):
         z_check = z[0]
 
         for elem in [u, w, z]:
-            if xp.any((elem < 0) | (elem > 1)):
+            if self.xp.any((elem < 0) | (elem > 1)):
                 raise ValueError("Amplitude interpolant accessed out-of-bounds.")
 
         region_mask = self.xp.asarray(region_mask)

--- a/src/few/summation/interpolatedmodesum.py
+++ b/src/few/summation/interpolatedmodesum.py
@@ -308,6 +308,7 @@ class InterpolatedModeSum(SummationBase):
         *args,
         dt: float = 10.0,
         integrate_backwards: bool = False,
+        include_minus_mkn: bool = True,
         **kwargs,
     ):
         r"""Interpolated summation function.
@@ -345,7 +346,8 @@ class InterpolatedModeSum(SummationBase):
         y_all = self.xp.zeros((ninterps, length))
 
         y_all[:num_teuk_modes] = teuk_modes.T.real
-        y_all[num_teuk_modes : 2 * num_teuk_modes] = teuk_modes.T.imag
+        if include_minus_mkn:
+            y_all[num_teuk_modes : 2 * num_teuk_modes] = teuk_modes.T.imag
 
         spline = self.build_with_same_backend(CubicSplineInterpolant, args=[t, y_all])
 

--- a/src/few/summation/interpolatedmodesum.py
+++ b/src/few/summation/interpolatedmodesum.py
@@ -169,7 +169,7 @@ class CubicSplineInterpolant(ParallelModuleBase):
 
         if np.any(inds < 0) or np.any(inds >= self.t.shape[1]):
             get_logger().warning(
-                "New t array outside bounds of input t array. These points are filled with edge values."
+                "(CubicSplineInterpolant) Warning: New t array outside bounds of input t array. These points are filled with edge values."
             )
         return inds, inds_bad_left, inds_bad_right
 
@@ -308,7 +308,6 @@ class InterpolatedModeSum(SummationBase):
         *args,
         dt: float = 10.0,
         integrate_backwards: bool = False,
-        include_minus_mkn: bool = True,
         **kwargs,
     ):
         r"""Interpolated summation function.
@@ -346,8 +345,7 @@ class InterpolatedModeSum(SummationBase):
         y_all = self.xp.zeros((ninterps, length))
 
         y_all[:num_teuk_modes] = teuk_modes.T.real
-        if include_minus_mkn:
-            y_all[num_teuk_modes : 2 * num_teuk_modes] = teuk_modes.T.imag
+        y_all[num_teuk_modes : 2 * num_teuk_modes] = teuk_modes.T.imag
 
         spline = self.build_with_same_backend(CubicSplineInterpolant, args=[t, y_all])
 

--- a/src/few/utils/mappings/kerrecceq.py
+++ b/src/few/utils/mappings/kerrecceq.py
@@ -152,7 +152,7 @@ def kerrecceq_forward_map(
     pLSO = get_separatrix(a_sep_in, e, xI_sep_in)
 
     # handle regions A and B
-    near = p < pLSO + DELTAPMAX
+    near = p <= pLSO + DELTAPMAX
     if xp.any(near):
         out = _uwyz_of_apex_kernel(
             a[near], p[near], e[near], xI[near], pLSO[near], alpha, beta

--- a/src/few/utils/modeselector.py
+++ b/src/few/utils/modeselector.py
@@ -209,6 +209,8 @@ class ModeSelector(ParallelModuleBase):
                 self.negative_m_flag = True
             if self.xp.any(self.xp.abs(self.mode_arr[:, 1]) > self.mode_arr[:, 0]):
                 raise ValueError("Mode selection has unphysical |m| > l mode(s).")
+            if self.xp.any(self.mode_arr[:, 0] < 2):
+                raise ValueError("Mode selection has unphysical l < 2 mode(s).")
             
         else:
             self.mode_arr = None
@@ -320,6 +322,8 @@ class ModeSelector(ParallelModuleBase):
                     )
             if self.xp.any(self.xp.abs(mode_arr[:, 1]) > mode_arr[:, 0]):
                 raise ValueError("Mode selection has unphysical |m| > l mode(s).")
+            if self.xp.any(mode_arr[:, 0] < 2):
+                raise ValueError("Mode selection has unphysical l < 2 mode(s).")
             
             if modeinds_map is None:
                 raise ValueError("If mode_selection is a list, modeinds_map must be provided.")

--- a/src/few/utils/modeselector.py
+++ b/src/few/utils/modeselector.py
@@ -207,6 +207,8 @@ class ModeSelector(ParallelModuleBase):
                     "(ModeSelector) Warning: Only supports mode_selection with m < 0 if include_minus_mkn = False. May lead to error during evaluation."
                 )
                 self.negative_m_flag = True
+            if self.xp.any(self.xp.abs(self.mode_arr[:, 1]) > self.mode_arr[:, 0]):
+                raise ValueError("Mode selection has unphysical |m| > l mode(s).")
             
         else:
             self.mode_arr = None
@@ -316,6 +318,8 @@ class ModeSelector(ParallelModuleBase):
                     raise ValueError(
                         "Only supports mode_selection with m >= 0 when include_minus_mkn = True."
                     )
+            if self.xp.any(self.xp.abs(mode_arr[:, 1]) > mode_arr[:, 0]):
+                raise ValueError("Mode selection has unphysical |m| > l mode(s).")
             
             if modeinds_map is None:
                 raise ValueError("If mode_selection is a list, modeinds_map must be provided.")

--- a/src/few/utils/utility.py
+++ b/src/few/utils/utility.py
@@ -1588,7 +1588,7 @@ def _get_separatrix_kernel_inner(a: float, e: float, x: float, tol: float = 1e-1
         x_hi = 8.0
 
         polar_p_sep = _brentq_jit(_separatrix_polynomial_polar, x_lo, x_hi, (a, e), tol)
-
+    
         if x == 0.0:
             return polar_p_sep
 
@@ -1679,7 +1679,7 @@ def get_separatrix(
 
     assert len(a_in) == len(e_in) == len(x_in)
 
-    separatrix = xp.empty_like(e_in)
+    separatrix = xp.empty_like(e_in, dtype=float)
     if use_gpu:
         threadsperblock = 256
         blockspergrid = (len(a_in) + (threadsperblock - 1)) // threadsperblock

--- a/src/few/utils/ylm.py
+++ b/src/few/utils/ylm.py
@@ -297,7 +297,7 @@ class GetYlms(ParallelModuleBase):
     :math:`Y_{lm}(\Theta,\phi)`.
 
     args:
-        include_minus_m: Set true if only providing :math:`m\geq0`,
+        include_minus_m: Set True if only providing :math:`m\geq0`,
             it will return twice the number of requested modes with the second
             half as modes with :math:`m<0` for array inputs of :math:`l,m`. **Warning**: It will also duplicate
             the :math:`m=0` modes. Default is False.

--- a/src/few/utils/ylm.py
+++ b/src/few/utils/ylm.py
@@ -297,7 +297,7 @@ class GetYlms(ParallelModuleBase):
     :math:`Y_{lm}(\Theta,\phi)`.
 
     args:
-        assume_positive_m: Set true if only providing :math:`m\geq0`,
+        include_minus_m: Set true if only providing :math:`m\geq0`,
             it will return twice the number of requested modes with the second
             half as modes with :math:`m<0` for array inputs of :math:`l,m`. **Warning**: It will also duplicate
             the :math:`m=0` modes. Default is False.
@@ -305,9 +305,9 @@ class GetYlms(ParallelModuleBase):
             :class:`few.utils.baseclasses.ParallelModuleBase`.
     """
 
-    def __init__(self, assume_positive_m: bool = False, **kwargs: Optional[dict]):
+    def __init__(self, include_minus_m: bool = False, **kwargs: Optional[dict]):
         ParallelModuleBase.__init__(self, **kwargs)
-        self.assume_positive_m = assume_positive_m
+        self.include_minus_m = include_minus_m
 
     @classmethod
     def supported_backends(cls):
@@ -337,7 +337,7 @@ class GetYlms(ParallelModuleBase):
             
         # if assuming positive m, repeat entries for negative m
         # this will duplicate m = 0
-        if self.assume_positive_m:
+        if self.include_minus_m:
             l = self.xp.zeros(2 * l_in.shape[0], dtype=int)
             m = self.xp.zeros(2 * l_in.shape[0], dtype=int)
 

--- a/src/few/waveform/base.py
+++ b/src/few/waveform/base.py
@@ -350,27 +350,6 @@ class SphericalHarmonicWaveformBase(
                 factor = amp_norm_temp / amp_for_norm
                 teuk_modes = teuk_modes * factor[:, np.newaxis]
 
-            # # different types of mode selection
-            # # sets up ylm and teuk_modes properly for summation
-            # if isinstance(mode_selection, str):
-            #     # use all modes
-            #     if mode_selection == "all":
-            #         self.ls = self.l_arr[: teuk_modes.shape[1]]
-            #         self.ms = self.m_arr[: teuk_modes.shape[1]]
-            #         self.ns = self.n_arr[: teuk_modes.shape[1]]
-
-            #         keep_modes = self.xp.arange(teuk_modes.shape[1])
-            #         temp2 = keep_modes * (keep_modes < self.num_m0) + (
-            #             keep_modes + self.num_m_1_up
-            #         ) * (keep_modes >= self.num_m0)
-
-            #         ylmkeep = self.xp.concatenate([keep_modes, temp2])
-            #         ylms_in = ylms[ylmkeep]
-            #         teuk_modes_in = teuk_modes
-
-            #     else:
-            #         raise ValueError("If mode selection is a string, must be `all`.")
-
             # # get a specific subset of modes
             # elif isinstance(mode_selection, list):
             #     if len(mode_selection) == 0:
@@ -482,39 +461,16 @@ class SphericalHarmonicWaveformBase(
             #     # remove modes if include_minus_m is False
             #     ylms_in[fix_include_ms] = 0.0 + 1j * 0.0
 
-            # # mode selection based on input module
-            # else:
-                # fund_freq_args = (
-                #     M,
-                #     0.0,
-                #     p_temp,
-                #     e_temp,
-                #     self.xp.zeros_like(e_temp),
-                #     t_temp,
-                # )
-                # modeinds = [self.l_arr, self.m_arr, self.n_arr]
-                # (
-                #     teuk_modes_in,
-                #     ylms_in,
-                #     self.ls,
-                #     self.ms,
-                #     self.ns,
-                # ) = self.mode_selector(
-                #     teuk_modes,
-                #     ylms,
-                #     modeinds,
-                #     fund_freq_args=fund_freq_args,
-                #     eps=eps,
-                # )
             fund_freq_args = (
                     M,
-                    0.0,
+                    a,
                     p_temp,
                     e_temp,
                     self.xp.zeros_like(e_temp),
                     t_temp,
                 )
             modeinds = [self.l_arr, self.m_arr, self.n_arr]
+            modeinds_map=self.special_index_map_arr
             (
                 teuk_modes_in,
                 ylms_in,
@@ -527,7 +483,7 @@ class SphericalHarmonicWaveformBase(
                 modeinds,
                 fund_freq_args=fund_freq_args,
                 mode_selection=mode_selection,
-                modeinds_map=self.special_index_map_arr,
+                modeinds_map=modeinds_map,
                 eps=eps,
             )
 

--- a/src/few/waveform/base.py
+++ b/src/few/waveform/base.py
@@ -328,7 +328,7 @@ class SphericalHarmonicWaveformBase(
                     a,
                     p_temp,
                     e_temp,
-                    self.xp.zeros_like(e_temp),
+                    xI,
                     t_temp,
                 )
             modeinds = [self.l_arr, self.m_arr, self.n_arr]

--- a/tests/test_fd.py
+++ b/tests/test_fd.py
@@ -34,7 +34,7 @@ class WaveformTest(unittest.TestCase):
 
         # keyword arguments for Ylm generator (GetYlms)
         Ylm_kwargs = {
-            "assume_positive_m": False  # if we assume positive m, it will generate negative m for all m>0
+            "include_minus_m": False  # if we include positive m, it will generate negative m for all m>0
         }
 
         # keyword arguments for summation generator (InterpolatedModeSum)

--- a/tests/test_few.py
+++ b/tests/test_few.py
@@ -38,7 +38,7 @@ class WaveformTest(unittest.TestCase):
 
         # keyword arguments for Ylm generator (GetYlms)
         Ylm_kwargs = {
-            "assume_positive_m": False  # if we assume positive m, it will generate negative m for all m>0
+            "include_minus_m": False  # if we assume positive m, it will generate negative m for all m>0
         }
 
         # keyword arguments for summation generator (InterpolatedModeSum)
@@ -86,7 +86,7 @@ class WaveformTest(unittest.TestCase):
 
         # keyword arguments for Ylm generator (GetYlms)
         Ylm_kwargs = {
-            "assume_positive_m": False  # if we assume positive m, it will generate negative m for all m>0
+            "include_minus_m": False  # if we assume positive m, it will generate negative m for all m>0
         }
 
         # keyword arguments for summation generator (InterpolatedModeSum)
@@ -113,7 +113,7 @@ class WaveformTest(unittest.TestCase):
 
         # keyword arguments for Ylm generator (GetYlms)
         Ylm_kwargs = {
-            "assume_positive_m": False  # if we assume positive m, it will generate negative m for all m>0
+            "include_minus_m": False  # if we assume positive m, it will generate negative m for all m>0
         }
 
         # keyword arguments for summation generator (InterpolatedModeSum)

--- a/tests/test_mode_selector.py
+++ b/tests/test_mode_selector.py
@@ -25,7 +25,7 @@ class ModeSelectorTest(unittest.TestCase):
     def test_mode_selector(self):
         # first, lets get amplitudes for a trajectory
         traj = EMRIInspiral(func=SchwarzEccFlux)
-        ylm_gen = GetYlms(assume_positive_m=True, force_backend="cpu")
+        ylm_gen = GetYlms(include_minus_m=True, force_backend="cpu")
 
         # parameters
         M = 1e5


### PR DESCRIPTION
This is a redesign of the `mode_selection` functionality within FEW. Main changes:

- Changed all of the `include_minus_m` to `include_minus_mkn`
- Changed `assume_minus_m` in `GetYlms` to `include_minus_m`
- Mode selection now takes place within `ModeSelector` class instead of the `SphericalHarmonicWaveformBase` class
    - This means that users can also pass `kwargs` for instantiating `ModeSelector` when instantiating waveform class
        - The big advantage is now users can give default values of `mode_selection` and `include_minus_mkn` when instantiating everything rather than having to specify modes (and checking them) at call time. 
- `mode_selection` can be one of the following options:
    - None
    - "all": use all modes
    - "eps": override all other mode selection options to use `eps` threshold option
    - list of tuples: this can include $m$ modes with any sign. However, if $m<0$ modes are included, then one must also specify `include_minus_mkn = False`. Additionally, there cannot be any duplicate modes.

Hopefully this helps clean up the handling of modes at the waveform level. There are still some lingering inefficiencies. For example, we technically calculate both $(m,k,n)$ and $(-m,-k,-n)$ modes. Therefore, if `include_minus_mkn = False`, then we set the $Y_{l,-m}$ that multiplies the $(-m,-k,-n)$ modes to zero.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--54.org.readthedocs.build/en/54/

<!-- readthedocs-preview fastemriwaveforms end -->