### PR TITLE
Try to fix file download

### DIFF
--- a/src/few/files/manager.py
+++ b/src/few/files/manager.py
@@ -323,7 +323,7 @@ class FileManager:
         import requests
 
         try:
-            response = requests.get(url, stream=True)
+            response = requests.get(url, stream=True, timeout=5)
             response.raise_for_status()
         except requests.exceptions.ConnectionError as e:
             raise exceptions.FileDownloadConnectionError() from e

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -11,4 +11,11 @@ class TestFew(TestProgram):
 
 
 if __name__ == "__main__":
+    from few import get_file_manager, get_logger, get_config_setter
+
+    get_config_setter().set_log_level("INFO")
+    get_logger().info("Ensuring that all files required by tests are present.")
+    get_file_manager().prefetch_files_by_tag("unittest")
+    get_logger().info("Done... Now run the tests!")
+    get_config_setter(reset=True)
     TestFew()


### PR DESCRIPTION
This PR adresses #42 .

I do not know why @thompsonphys had download issues in such a variety of situations (local workstation, cluster, wired and wifi, ...). But to prevent the indefinite hanging,  I added a timeout of 5s on file download so that download will fail if the server stops responding for at least 5s (it does not mean that downloads must be completed under 5s).

Hopefully this will fail gracefully in case of hanging download with an error message explicit enough to understand the underlying cause of the issue. Note that in case of such a failure, the download will be automatically reattempted 3 times (by default).

I also modified the tests execution script. Now when running `python -m few.tests`, the code will first download all required files (if needed) and only then will start tests execution. This way, the test timing (`Ran 42 tests in 156.727s`) will not be polluted by file download time.


<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--56.org.readthedocs.build/en/56/

<!-- readthedocs-preview fastemriwaveforms end -->