### PR TITLE
feat: improve detection of missing CUDA requirements

### DIFF
--- a/src/few/cutils/__init__.py
+++ b/src/few/cutils/__init__.py
@@ -243,7 +243,11 @@ class _CudaBackend(Backend):
                 conda_deps=[],
             ) from e
 
-        cupy_cuda_ver = cupy.cuda.get_local_runtime_version() // 1000
+        try:
+            cupy_cuda_ver = cupy.cuda.get_local_runtime_version() // 1000
+        except RuntimeError as e:
+            raise SoftwareException("CuPy could not detect runtime version") from e
+
         if cupy_cuda_ver != cuda_major:
             raise MissingDependencies(
                 "CuPy is installed but supports CUDA {} instead of {}".format(
@@ -255,6 +259,7 @@ class _CudaBackend(Backend):
 
         try:
             _ = cupy.arange(1)
+            _ = cupy.cuda.runtime.getDevice()
         except cupy.cuda.compiler.CompileException as e:
             raise MissingDependencies(
                 "CuPy fails to run due to missing CUDA Runtime.",


### PR DESCRIPTION
This PR Adresses part of #57 .

It ensures that CUDA backend fails to load in no CUDA device is available.

Now on a GPU enabled cluster node, I have the following behaviour:

```sh
$ python -c "import few; few.get_backend("cuda12x")"
<few.cutils.Cuda12xBackend object at 0x1515184bb0b0>
$ CUDA_VISIBLE_DEVICES=-1 python -c "import few; few.get_backend("cuda12x")"
Traceback (most recent call last):
 [...]
cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorNoDevice: no CUDA-capable device is detected

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
 [...]
few.cutils.SoftwareException: CuPy could not execute properly.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
 [...]
few.cutils.BackendAccessException: Backend 'cuda12x' is unavailable. See previous error messages
```

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--58.org.readthedocs.build/en/58/

<!-- readthedocs-preview fastemriwaveforms end -->