### PR TITLE
Added ability to use downsample functionlity from trajectory module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ src/*/git_version.py
 
 # Ignore symlink in editable mode
 src/few/CITATION.cff
+
+# Ignore MacOS DS_Store files
+*.DS_Store

--- a/src/few/trajectory/integrate.py
+++ b/src/few/trajectory/integrate.py
@@ -83,6 +83,7 @@ class Integrate:
         self,
         func: Type[ODEBase],
         integrate_constants_of_motion: bool = False,
+        downsample = None,
         buffer_length: int = 10000,
         enforce_schwarz_sep: bool = False,
         max_iter: Optional[int] = None,
@@ -95,7 +96,7 @@ class Integrate:
         self.base_func = func
 
         # load func
-        self.func = func(use_ELQ=integrate_constants_of_motion, **kwargs)
+        self.func = func(use_ELQ=integrate_constants_of_motion,downsample=downsample, **kwargs)
 
         self.ode_info = get_ode_properties(self.func)
 

--- a/src/few/trajectory/ode/flux.py
+++ b/src/few/trajectory/ode/flux.py
@@ -233,7 +233,7 @@ class KerrEccEqFlux(ODEBase):
     """
 
     def __init__(self, *args, use_ELQ: bool = False, downsample=None, flux_output_convention="pex", **kwargs):
-        super().__init__(*args, use_ELQ=use_ELQ, **kwargs)
+        super().__init__(*args, use_ELQ=use_ELQ, downsample=downsample, **kwargs)
 
         self.flux_output_convention = flux_output_convention
 


### PR DESCRIPTION
The functionality to downsample the flux was already present in the KerrEqEcc base class, however, there was no convenient way to pass the list downsample parameters through the EMRIInspiral class. I've added an additional keyword argument to the _init_ of the Integrate class allow us to do this easily. This makes it possible to produce inspirals and waveforms using different grid densities. 

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--59.org.readthedocs.build/en/59/

<!-- readthedocs-preview fastemriwaveforms end -->