### PR TITLE
Prepare project for conda packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,13 @@ version_file = "src/few/_version.py"
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = [ "src/few/_version.py", "src/few/git_version.py", "tests/" ]
+sdist.include = [
+  "src/few/_version.py",
+  "src/few/git_version.py",                 #@SKIP_PLUGIN@
+  "src/few_backend_cuda11x/git_version.py",
+  "src/few_backend_cuda12x/git_version.py",
+  "tests/",
+]
 sdist.exclude = [
   ".devcontainer/",
   ".github/",
@@ -178,4 +184,5 @@ report.omit = [
   "*/few/_version.py",
   "*/few/tests/*.py",
   "*/few/git_version.py",
+  "*/few_backend_*/git_version.py",
 ]

--- a/src/few/CMakeLists.txt
+++ b/src/few/CMakeLists.txt
@@ -2,8 +2,10 @@
 add_subdirectory(cutils)
 
 # Handle Git Metadata
-message(CHECK_START "Building few.git_version metadata")
+get_target_property(_FEW_WITH_CPU fastemriwaveforms WITH_CPU)
+get_target_property(_FEW_WITH_GPU fastemriwaveforms WITH_GPU)
 
+message(CHECK_START "Building few.git_version metadata")
 message(CHECK_START "Find Git executable")
 find_package(Git)
 if(Git_FOUND)
@@ -30,7 +32,15 @@ if(Git_FOUND)
 
     configure_file(git_version.py.in git_version.py @ONLY)
 
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/git_version.py DESTINATION few)
+    if(_FEW_WITH_CPU)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/git_version.py DESTINATION few)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/git_version.py
+              DESTINATION few_backend_cpu)
+    endif()
+    if(_FEW_WITH_GPU)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/git_version.py
+              DESTINATION few_backend_cuda${CUDAToolkit_VERSION_MAJOR}x)
+    endif()
 
     message(CHECK_PASS "done")
   else()

--- a/src/few/cutils/global.h
+++ b/src/few/cutils/global.h
@@ -1,21 +1,17 @@
 #ifndef _GLOBAL_HEADER_
 #define _GLOBAL_HEADER_
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <complex>
-#include "cuda_complex.hpp"
-
 #if defined(_MSC_VER)
-    #define LAPACK_COMPLEX_CUSTOM
-    #define lapack_complex_float _Fcomplex
-    #define lapack_complex_double _Dcomplex
     #define _USE_MATH_DEFINES
     #define FEW_INLINE __inline
 #else
     #define FEW_INLINE __inline__
 #endif
 
+#include <stdlib.h>
+#include <stdio.h>
+#include <complex>
+#include "cuda_complex.hpp"
 #include <cmath>
 
 // Definitions needed for Mathematicas CForm output

--- a/src/few/cutils/gpuAAK.cu
+++ b/src/few/cutils/gpuAAK.cu
@@ -1,5 +1,3 @@
-#include "stdio.h"
-
 #include "global.h"
 
 #define  NUM_THREADS 32
@@ -158,16 +156,16 @@ void d_RotCoeff(double* rot, double* n, double* L, double* S, double* nxL, doubl
 
   double norm=d_vec_norm(nxL)*d_vec_norm(nxS);
   double dot,cosrot,sinrot;
-  
+
   dot = d_dot_product(nxL,nxS);
 
   if (norm < 1e-6) norm = 1e-6;
 
   cosrot=dot/norm;
-  
+
   dot = d_dot_product(L,nxS);
   sinrot=dot;
-  
+
   dot = d_dot_product(S,nxL);
   sinrot-=dot;
   sinrot/=norm;
@@ -186,7 +184,7 @@ void make_waveform(cmplx *waveform,
               double M_phys, double S_phys, double mu, double qS, double phiS, double qK, double phiK, double dist,
               int nmodes, bool mich,
               double delta_t, double start_t, int old_ind, int start_ind, int end_ind, int init_length, double segwidth)
-{ 
+{
 
       #ifdef __CUDACC__
 
@@ -271,9 +269,9 @@ void make_waveform(cmplx *waveform,
       double sinphiK=sin(phiK);
       double halfsqrt3=sqrt(3.)/2.;
 
-      // Defined in global.h file 
+      // Defined in global.h file
       double mu_sec = mu * MTSUN_SI;
-      double zeta=mu_sec/dist/GPCINSEC; 
+      double zeta=mu_sec/dist/GPCINSEC;
 
       #ifdef __CUDACC__
 
@@ -354,9 +352,9 @@ void make_waveform(cmplx *waveform,
           double Ldotn2=Ldotn*Ldotn;
           double Sdotn=cosqK*cosqS+sinqK*sinqS*cos(phiK-phiS);
           double beta;
-          if (S_phys == 0.0 || lam < 1e-10 || lam > (M_PI - 1e-10)) // Useful fix to make AAK match Kerr. 
+          if (S_phys == 0.0 || lam < 1e-10 || lam > (M_PI - 1e-10)) // Useful fix to make AAK match Kerr.
           {
-              beta = 0.0; 
+              beta = 0.0;
           }
           else
           {
@@ -386,7 +384,7 @@ void make_waveform(cmplx *waveform,
           double sin2phi=sin(2.*phiw);
           double cos2psi=cos(2.*psi);
           double sin2psi=sin(2.*psi);
-          // antenna patterns, detector frame 
+          // antenna patterns, detector frame
           FplusI=cosq1*cos2phi*cos2psi-cosq*sin2phi*sin2psi;
           FcrosI=cosq1*cos2phi*sin2psi+cosq*sin2phi*cos2psi;
           FplusII=cosq1*sin2phi*cos2psi+cosq*cos2phi*sin2psi;
@@ -394,7 +392,7 @@ void make_waveform(cmplx *waveform,
         }
         else
         {
-            // Antenna patterns, source frame 
+            // Antenna patterns, source frame
             FplusI = 1.0;
             FcrosI = 0.0;
             FplusII = 0.0;

--- a/src/few/cutils/interpolate.cu
+++ b/src/few/cutils/interpolate.cu
@@ -23,6 +23,11 @@
 #ifdef __CUDACC__
 #include "cusparse.h"
 #else
+#if defined(_MSC_VER)
+#include <complex>
+#define lapack_complex_float std::complex<float>
+#define lapack_complex_double std::complex<double>
+#endif
 #include "lapacke.h"
 #endif
 


### PR DESCRIPTION
This PR

- fixes the compilation of FEW CPU backend on windows
- propagate the file `git_version.py` not only in `few/` but also in the `few_backend_[cpu|cuda11x|cuda12x]` directories so that we can check at runtimes that with have plugins whose commit match that of the core package

Using this version of the code, I managed to prepare conda packaging for `linux64`, `win64`, `osx64` and `linux64_cuda126` architectures (I did not manage to handle CUDA 11 for conda-forge, the conda environment for CUDA 11 was quite unstable and was split between a `nvidia` channel and the `conda-forge` channel. Things have settled for CUDA 12 so I'm only supporting that now.

The actual conda packaging will be made available only when the official 2.0 release will be out (for future versions, I'll be able to publish release candidates on conda-forge, but not for the initial version).

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--63.org.readthedocs.build/en/63/

<!-- readthedocs-preview fastemriwaveforms end -->