### PR TITLE
Small code clean-ups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ extend-include = [
 ]
 
 lint.extend-select = [
+  "I",
   "T201", # Fail when "print" is used, to be replaced with logger calls
 ]
 

--- a/src/few/utils/utility.py
+++ b/src/few/utils/utility.py
@@ -58,28 +58,13 @@ def get_overlap(
     # adjust arrays based on GPU usage
     if use_gpu:
         import cupy as xp
-
-        if isinstance(time_series_1, np.ndarray):
-            time_series_1 = xp.asarray(time_series_1)
-        if isinstance(time_series_2, np.ndarray):
-            time_series_2 = xp.asarray(time_series_2)
-
     else:
         xp = np
 
-        try:
-            if isinstance(time_series_1, cp.ndarray):
-                time_series_1 = xp.asarray(time_series_1)
-
-        except NameError:
-            pass
-
-        try:
-            if isinstance(time_series_2, cp.ndarray):
-                time_series_2 = xp.asarray(time_series_2)
-
-        except NameError:
-            pass
+    if not isinstance(time_series_1, xp.ndarray):
+        time_series_1 = xp.asarray(time_series_1)
+    if not isinstance(time_series_2, xp.ndarray):
+        time_series_2 = xp.asarray(time_series_2)
 
     # get the lesser of the two lengths
     min_len = int(np.min([len(time_series_1), len(time_series_2)]))
@@ -106,9 +91,7 @@ def get_overlap(
     )
 
     # if using cupy, it will return a dimensionless array
-    if use_gpu:
-        return ac.item().real
-    return ac.real
+    return ac.item().real if use_gpu else ac.real
 
 
 def get_mismatch(

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -11,9 +11,13 @@ class TestFew(TestProgram):
 
 
 if __name__ == "__main__":
-    from few import get_file_manager, get_logger, get_config_setter
+    import logging
 
-    get_config_setter().set_log_level("INFO")
+    from few import get_config_setter, get_file_manager, get_logger
+
+    if get_logger().getEffectiveLevel() > logging.INFO:
+        get_config_setter(reset=True).set_log_level("INFO")
+
     get_logger().info("Ensuring that all files required by tests are present.")
     get_file_manager().prefetch_files_by_tag("unittest")
     get_logger().info("Done... Now run the tests!")

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,6 +1,7 @@
 """Definition of baseclass for FEW tests"""
 
 import abc
+import gc
 import logging
 import typing as t
 import unittest
@@ -31,7 +32,12 @@ class FewTest(unittest.TestCase, abc.ABC):
     def tearDownClass(cls):
         cls.logger.warning("\n  Test '%s': done.", cls.name())
         del cls.logger
+        gc.collect()
         super().tearDownClass()
+
+    def tearDown(self):
+        gc.collect()
+        return super().tearDown()
 
 
 class FewBackendTest(FewTest):

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,59 @@
+"""Definition of baseclass for FEW tests"""
+
+import abc
+import logging
+import typing as t
+import unittest
+
+from few.cutils import Backend
+from few.utils.baseclasses import ParallelModuleBase
+from few.utils.globals import get_first_backend, get_logger
+
+
+class FewTest(unittest.TestCase, abc.ABC):
+    """Baseclass for FEW tests with logger"""
+
+    logger: logging.Logger
+
+    @classmethod
+    @abc.abstractmethod
+    def name(cls) -> str:
+        """Name of the test"""
+        raise NotImplementedError
+
+    @classmethod
+    def setUpClass(cls):
+        cls.logger = get_logger()
+        cls.logger.warning("Test '%s' is starting.", cls.name())
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.logger.warning("\n  Test '%s': done.", cls.name())
+        del cls.logger
+        super().tearDownClass()
+
+
+class FewBackendTest(FewTest):
+    """Base class for FEW tests with backend"""
+
+    backend: Backend
+
+    @classmethod
+    @abc.abstractmethod
+    def parallel_class(cls) -> t.Type[ParallelModuleBase]:
+        """Class to be used as reference for the test backend selection"""
+        raise NotImplementedError
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = get_first_backend(cls.parallel_class().supported_backends())
+        cls.logger.warning(
+            "  Test '%s': running with backend '%s'", cls.name(), cls.backend.name
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.backend
+        super().tearDownClass()

--- a/tests/test_amplitudes.py
+++ b/tests/test_amplitudes.py
@@ -1,70 +1,83 @@
-import unittest
 import numpy as np
 
-from few.amplitude.ampinterp2d import AmpInterpKerrEccEq, AmpInterpSchwarzEcc
-from few.utils.globals import get_logger, get_first_backend
-
-few_logger = get_logger()
-
-best_backend = get_first_backend(AmpInterpKerrEccEq.supported_backends())
-few_logger.warning(
-    "Amplitudes test is running with backend '{}'".format(best_backend.name)
-)
+from few.amplitude.ampinterp2d import AmpInterpKerrEccEq
+from few.tests.base import FewBackendTest
 
 KERRECCEQ_AMP_TEST_POINTS = [
     {
-        'lmn' : (3, 2, 4),
-        'ape' : (0.94071396, 3.03167504, 0.23666111),
-        'Almn' : 0.002753336140076555+0.004143260615912325j,
+        "lmn": (3, 2, 4),
+        "ape": (0.94071396, 3.03167504, 0.23666111),
+        "Almn": 0.002753336140076555 + 0.004143260615912325j,
     },
     {
-        'lmn' : (2, -2, 5),
-        'ape' : (0.77593827, 5.44830674, 0.39950367),
-        'Almn' : -0.0001975310651632842+4.806588136412258e-05j,
+        "lmn": (2, -2, 5),
+        "ape": (0.77593827, 5.44830674, 0.39950367),
+        "Almn": -0.0001975310651632842 + 4.806588136412258e-05j,
     },
     {
-        'lmn' : (2, 2, 0),
-        'ape' : (0.99090693, 1.81708312, 0.25313127),
-        'Almn' : -0.09712303568244392+0.0004771647068539275j,
+        "lmn": (2, 2, 0),
+        "ape": (0.99090693, 1.81708312, 0.25313127),
+        "Almn": -0.09712303568244392 + 0.0004771647068539275j,
     },
     {
-        'lmn' : (4, -3, 1),
-        'ape' : (0.87600927, 43.70360964,  0.478125),
-        'Almn' : -9.89242565478408e-07+1.750469365836169e-05j,    
+        "lmn": (4, -3, 1),
+        "ape": (0.87600927, 43.70360964, 0.478125),
+        "Almn": -9.89242565478408e-07 + 1.750469365836169e-05j,
     },
     {
-        'lmn' : (3, 3, 0),
-        'ape' : (0.36158837, 72.94420732,  0.39375),
-        'Almn' : 5.869887391976143e-05+0.00136010620358342j,    
-    }
+        "lmn": (3, 3, 0),
+        "ape": (0.36158837, 72.94420732, 0.39375),
+        "Almn": 5.869887391976143e-05 + 0.00136010620358342j,
+    },
 ]
-class AmplitudesTest(unittest.TestCase):
+
+
+class AmplitudesTest(FewBackendTest):
+    @classmethod
+    def name(self) -> str:
+        return "Amplitudes"
+
+    @classmethod
+    def parallel_class(self):
+        return AmpInterpKerrEccEq
+
     def test_kerrecceq(self):
-        amp_module = AmpInterpKerrEccEq(force_backend=best_backend)
+        amp_module = AmpInterpKerrEccEq(force_backend=self.backend)
 
         # test if amplitude generation gives same values for scalar vs array inputs
         a = 0.3
         p = 8
         e = 0.4
-        xI = 1.
+        xI = 1.0
         amplitudes = amp_module(a, p, e, xI)
         amplitudes_array = amp_module(a, np.array([p]), np.array([e]), np.array([xI]))
-        if best_backend.uses_gpu:
-            np.testing.assert_allclose(amplitudes.get(), amplitudes_array.get(), rtol=1e-10)
+        if self.backend.uses_gpu:
+            np.testing.assert_allclose(
+                amplitudes.get(), amplitudes_array.get(), rtol=1e-10
+            )
         else:
             np.testing.assert_allclose(amplitudes, amplitudes_array, rtol=1e-10)
 
         # test the amplitudes at some random points against their numerical values
         for test_point in KERRECCEQ_AMP_TEST_POINTS:
-            a, p, e = test_point['ape']
-            mode_interp = amp_module(a, p, e, xI, specific_modes=[test_point['lmn']])[test_point['lmn']].item()
-        np.testing.assert_allclose(mode_interp, test_point['Almn'], rtol=0, atol=1e-9)
+            a, p, e = test_point["ape"]
+            mode_interp = amp_module(a, p, e, xI, specific_modes=[test_point["lmn"]])[
+                test_point["lmn"]
+            ].item()
+        np.testing.assert_allclose(mode_interp, test_point["Almn"], rtol=0, atol=1e-9)
 
         # test the mode symmetry
         specific_modes = [(3, 2, 1), (3, -2, -1)]
         specific_amplitudes = amp_module(a, p, e, xI, specific_modes=specific_modes)
-        if best_backend.uses_gpu:
-            np.testing.assert_allclose(specific_amplitudes[(3, 2, 1)].get(), -specific_amplitudes[(3, -2, -1)].conj().get(), rtol=1e-10)
+        if self.backend.uses_gpu:
+            np.testing.assert_allclose(
+                specific_amplitudes[(3, 2, 1)].get(),
+                -specific_amplitudes[(3, -2, -1)].conj().get(),
+                rtol=1e-10,
+            )
         else:
-            np.testing.assert_allclose(specific_amplitudes[(3, 2, 1)], -specific_amplitudes[(3, -2, -1)].conj(), rtol=1e-10)
-        
+            np.testing.assert_allclose(
+                specific_amplitudes[(3, 2, 1)],
+                -specific_amplitudes[(3, -2, -1)].conj(),
+                rtol=1e-10,
+            )

--- a/tests/test_detector_wave.py
+++ b/tests/test_detector_wave.py
@@ -1,99 +1,99 @@
-import unittest
 import pickle
 
-from few.waveform import GenerateEMRIWaveform, FastSchwarzschildEccentricFlux
-
-from few.utils.globals import get_logger, get_first_backend
-
-few_logger = get_logger()
-
-best_backend = get_first_backend(FastSchwarzschildEccentricFlux.supported_backends())
-few_logger.warning(
-    "DetectorWave test is running with backend '{}'".format(best_backend.name)
-)
+from few.tests.base import FewBackendTest
+from few.waveform import FastSchwarzschildEccentricFlux, GenerateEMRIWaveform
 
 
-def run_detector_frame_test(test_pickle=False):
-    # specific waveform kwargs
-    waveform_kwargs = dict(
-        force_backend=best_backend,
-    )
+class WaveformTest(FewBackendTest):
+    @classmethod
+    def name(self) -> str:
+        return "DetectorWave"
 
-    gen_wave = GenerateEMRIWaveform("FastSchwarzschildEccentricFlux", **waveform_kwargs)
+    @classmethod
+    def parallel_class(self):
+        return FastSchwarzschildEccentricFlux
 
-    gen_wave_aak = GenerateEMRIWaveform("Pn5AAKWaveform", **waveform_kwargs)
+    def run_detector_frame_test(self, test_pickle=False):
+        # specific waveform kwargs
+        waveform_kwargs = dict(
+            force_backend=self.backend,
+        )
 
-    # parameters
-    T = 0.001  # years
-    dt = 15.0  # seconds
-    M = 1e6
-    a = 0.1  # will be ignored in Schwarz waveform
-    mu = 1e1
-    p0 = 12.0
-    e0 = 0.2
-    Y0 = 1.0
-    qK = 0.2  # polar spin angle
-    phiK = 0.2  # azimuthal viewing angle
-    qS = 0.3  # polar sky angle
-    phiS = 0.3  # azimuthal viewing angle
-    dist = 1.0  # distance
-    Phi_phi0 = 1.0
-    Phi_theta0 = 2.0
-    Phi_r0 = 3.0
+        gen_wave = GenerateEMRIWaveform(
+            "FastSchwarzschildEccentricFlux", **waveform_kwargs
+        )
 
-    if test_pickle:
-        check_pickle_gen_wave = pickle.dumps(gen_wave)
-        extracted_gen_wave = pickle.loads(check_pickle_gen_wave)
+        gen_wave_aak = GenerateEMRIWaveform("Pn5AAKWaveform", **waveform_kwargs)
 
-        check_pickle_gen_wave_aak = pickle.dumps(gen_wave_aak)
-        extracted_gen_wave_aak = pickle.loads(check_pickle_gen_wave_aak)
+        # parameters
+        T = 0.001  # years
+        dt = 15.0  # seconds
+        M = 1e6
+        a = 0.1  # will be ignored in Schwarz waveform
+        mu = 1e1
+        p0 = 12.0
+        e0 = 0.2
+        Y0 = 1.0
+        qK = 0.2  # polar spin angle
+        phiK = 0.2  # azimuthal viewing angle
+        qS = 0.3  # polar sky angle
+        phiS = 0.3  # azimuthal viewing angle
+        dist = 1.0  # distance
+        Phi_phi0 = 1.0
+        Phi_theta0 = 2.0
+        Phi_r0 = 3.0
 
-    else:
-        extracted_gen_wave = gen_wave
-        extracted_gen_wave_aak = gen_wave_aak
+        if test_pickle:
+            check_pickle_gen_wave = pickle.dumps(gen_wave)
+            extracted_gen_wave = pickle.loads(check_pickle_gen_wave)
 
-    _ = extracted_gen_wave(
-        M,
-        mu,
-        a,
-        p0,
-        e0,
-        Y0,
-        dist,
-        qS,
-        phiS,
-        qK,
-        phiK,
-        Phi_phi0,
-        Phi_theta0,
-        Phi_r0,
-        T=T,
-        dt=dt,
-    )
+            check_pickle_gen_wave_aak = pickle.dumps(gen_wave_aak)
+            extracted_gen_wave_aak = pickle.loads(check_pickle_gen_wave_aak)
 
-    _ = extracted_gen_wave_aak(
-        M,
-        mu,
-        a,
-        p0,
-        e0,
-        Y0,
-        dist,
-        qS,
-        phiS,
-        qK,
-        phiK,
-        Phi_phi0,
-        Phi_theta0,
-        Phi_r0,
-        T=T,
-        dt=dt,
-    )
+        else:
+            extracted_gen_wave = gen_wave
+            extracted_gen_wave_aak = gen_wave_aak
 
+        _ = extracted_gen_wave(
+            M,
+            mu,
+            a,
+            p0,
+            e0,
+            Y0,
+            dist,
+            qS,
+            phiS,
+            qK,
+            phiK,
+            Phi_phi0,
+            Phi_theta0,
+            Phi_r0,
+            T=T,
+            dt=dt,
+        )
 
-class WaveformTest(unittest.TestCase):
+        _ = extracted_gen_wave_aak(
+            M,
+            mu,
+            a,
+            p0,
+            e0,
+            Y0,
+            dist,
+            qS,
+            phiS,
+            qK,
+            phiK,
+            Phi_phi0,
+            Phi_theta0,
+            Phi_r0,
+            T=T,
+            dt=dt,
+        )
+
     def test_pickle(self):
-        run_detector_frame_test(test_pickle=True)
+        self.run_detector_frame_test(test_pickle=True)
 
     def test_detector_frame(self):
-        run_detector_frame_test(test_pickle=False)
+        self.run_detector_frame_test(test_pickle=False)

--- a/tests/test_kerr.py
+++ b/tests/test_kerr.py
@@ -15,7 +15,7 @@ inspiral_kwargs_Kerr = {
 class KerrWaveformTest(FewBackendTest):
     @classmethod
     def name(self) -> str:
-        return "FD"
+        return "Kerr"
 
     @classmethod
     def parallel_class(self):

--- a/tests/test_kerr.py
+++ b/tests/test_kerr.py
@@ -1,18 +1,8 @@
-import unittest
-
 # from few.waveform import FastSchwarzschildEccentricFlux
-from few.waveform import GenerateEMRIWaveform
-
-from few.utils.utility import get_mismatch
-from few.waveform import FastKerrEccentricEquatorialFlux
+from few.tests.base import FewBackendTest
 from few.trajectory.ode import KerrEccEqFlux
-
-from few.utils.globals import get_logger, get_first_backend
-
-few_logger = get_logger()
-
-best_backend = get_first_backend(FastKerrEccentricEquatorialFlux.supported_backends())
-few_logger.warning("Kerr Test is running with backend {}".format(best_backend.name))
+from few.utils.utility import get_mismatch
+from few.waveform import FastKerrEccentricEquatorialFlux, GenerateEMRIWaveform
 
 # keyword arguments for inspiral generator (Kerr Waveform)
 inspiral_kwargs_Kerr = {
@@ -22,15 +12,23 @@ inspiral_kwargs_Kerr = {
 }
 
 
-class KerrWaveformTest(unittest.TestCase):
+class KerrWaveformTest(FewBackendTest):
+    @classmethod
+    def name(self) -> str:
+        return "FD"
+
+    @classmethod
+    def parallel_class(self):
+        return FastKerrEccentricEquatorialFlux
+
     def test_Kerr_vs_Schwarzchild(self):
         # Test whether the Kerr and Schwarzschild waveforms agree.
 
         wave_generator_Kerr = GenerateEMRIWaveform(
-            "FastKerrEccentricEquatorialFlux", force_backend=best_backend
+            "FastKerrEccentricEquatorialFlux", force_backend=self.backend
         )
         wave_generator_Schwarz = GenerateEMRIWaveform(
-            "FastSchwarzschildEccentricFlux", force_backend=best_backend
+            "FastSchwarzschildEccentricFlux", force_backend=self.backend
         )
 
         # parameters
@@ -89,7 +87,7 @@ class KerrWaveformTest(unittest.TestCase):
             dt=dt,
         )
 
-        mm = get_mismatch(Kerr_wave, Schwarz_wave, use_gpu=best_backend.uses_gpu)
+        mm = get_mismatch(Kerr_wave, Schwarz_wave, use_gpu=self.backend.uses_gpu)
 
         self.assertLess(mm, 1e-4)
 
@@ -98,10 +96,10 @@ class KerrWaveformTest(unittest.TestCase):
         Here we test that retrograde orbits and prograde orbits for a = \pm 0.7
         have large mismatches.
         """
-        few_logger.info("Testing retrograde orbits")
+        self.logger.info("Testing retrograde orbits")
 
         wave_generator_Kerr = GenerateEMRIWaveform(
-            "FastKerrEccentricEquatorialFlux", force_backend=best_backend
+            "FastKerrEccentricEquatorialFlux", force_backend=self.backend
         )
 
         # parameters
@@ -162,6 +160,6 @@ class KerrWaveformTest(unittest.TestCase):
         )
 
         mm = get_mismatch(
-            Kerr_wave_retrograde, Kerr_wave_prograde, use_gpu=best_backend.uses_gpu
+            Kerr_wave_retrograde, Kerr_wave_prograde, use_gpu=self.backend.uses_gpu
         )
         self.assertGreater(mm, 1e-3)

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -1,42 +1,48 @@
-import unittest
-
 import numpy as np
 
+from few.tests.base import FewTest
+from few.utils.mappings.kerrecceq import kerrecceq_backward_map, kerrecceq_forward_map
 from few.utils.mappings.pn import Y_to_xI, xI_to_Y
-from few.utils.mappings.kerrecceq import kerrecceq_forward_map, kerrecceq_backward_map
 from few.utils.utility import get_separatrix
-from few.utils.globals import get_logger, get_first_backend
 
-few_logger = get_logger()
 
-few_logger.warning(
-    "Mappings tests are running"
-)
+class MappingsTest(FewTest):
+    @classmethod
+    def name(self) -> str:
+        return "Mappings"
 
-class MappingsTest(unittest.TestCase):
     def test_kerrecceq_mapping(self):
-        
         # test the mapping is invertible
 
         # regionA
         a = 0.3
-        p = 8.
+        p = 8.0
         e = 0.4
-        xI = 1.
+        xI = 1.0
 
         for kind in ["flux", "amplitude"]:
             u, w, y, z = kerrecceq_forward_map(a, p, e, xI)
             a_new, p_new, e_new, xI_new = kerrecceq_backward_map(u, w, y, z)
 
-            np.testing.assert_allclose([a, p, e, xI], [a_new.item(), p_new.item(), e_new.item(), xI_new.item()], rtol=1e-10)
+            np.testing.assert_allclose(
+                [a, p, e, xI],
+                [a_new.item(), p_new.item(), e_new.item(), xI_new.item()],
+                rtol=1e-10,
+            )
 
         # regionB
-        p = 45.
-        for kind in ["flux", "amplitude"]: 
+        p = 45.0
+        for kind in ["flux", "amplitude"]:
             u, w, y, z = kerrecceq_forward_map(a, p, e, xI, kind=kind)
-            a_new, p_new, e_new, xI_new = kerrecceq_backward_map(u, w, y, z, regionA=False, kind=kind)
-            
-            np.testing.assert_allclose([a, p, e, xI], [a_new.item(), p_new.item(), e_new.item(), xI_new.item()], rtol=1e-10)
+            a_new, p_new, e_new, xI_new = kerrecceq_backward_map(
+                u, w, y, z, regionA=False, kind=kind
+            )
+
+            np.testing.assert_allclose(
+                [a, p, e, xI],
+                [a_new.item(), p_new.item(), e_new.item(), xI_new.item()],
+                rtol=1e-10,
+            )
 
         # check the mapping at the inner p boundary for NaNs due to logarithmic scaling
         p = get_separatrix(a, e, xI) + 1e-3
@@ -44,10 +50,9 @@ class MappingsTest(unittest.TestCase):
         self.assertFalse(np.isnan(u))
 
     def test_PN_mapping(self):
-
         # Check whether Y->xI and xI->Y are inverses
         a = 0.3
-        p = 8.
+        p = 8.0
         e = 0.4
         Y = 0.3
 
@@ -57,7 +62,7 @@ class MappingsTest(unittest.TestCase):
         np.testing.assert_allclose(Y_new, Y, rtol=1e-10)
 
         # check that equatorial maps to equatorial
-        Y = 1.
+        Y = 1.0
 
         xI = Y_to_xI(a, p, e, Y)
         Y_new = xI_to_Y(a, p, e, xI)
@@ -66,11 +71,13 @@ class MappingsTest(unittest.TestCase):
         np.testing.assert_allclose(xI, Y, rtol=1e-10)
 
         # check that polar maps to polar
-        Y = 0.
-        
+        Y = 0.0
+
         xI = Y_to_xI(a, p, e, Y)
 
         np.testing.assert_allclose(xI, Y, rtol=1e-10)
 
         # check integer arguments doesn't break things
-        np.testing.assert_allclose(Y_to_xI(0.3, 8, 0.4, 1), Y_to_xI(0.3, 8., 0.4, 1.), rtol=1e-10)
+        np.testing.assert_allclose(
+            Y_to_xI(0.3, 8, 0.4, 1), Y_to_xI(0.3, 8.0, 0.4, 1.0), rtol=1e-10
+        )

--- a/tests/test_mode_selector.py
+++ b/tests/test_mode_selector.py
@@ -1,27 +1,26 @@
-import unittest
 import numpy as np
 
-from few.trajectory.inspiral import EMRIInspiral
-from few.utils.ylm import GetYlms
-from few.utils.modeselector import ModeSelector
-from few.summation.interpolatedmodesum import CubicSplineInterpolant
 from few.amplitude.romannet import RomanAmplitude
-from few.waveform import FastSchwarzschildEccentricFluxBicubic
-from few.utils.utility import get_mismatch
+from few.summation.interpolatedmodesum import CubicSplineInterpolant
+from few.tests.base import FewBackendTest
+from few.trajectory.inspiral import EMRIInspiral
 from few.trajectory.ode import SchwarzEccFlux
-from few.utils.globals import get_logger, get_first_backend, get_file_manager
-
-few_logger = get_logger()
-
-best_backend = get_first_backend(
-    FastSchwarzschildEccentricFluxBicubic.supported_backends()
-)
-few_logger.warning(
-    "ModeSelector Test is running with backend {}".format(best_backend.name)
-)
+from few.utils.globals import get_file_manager
+from few.utils.modeselector import ModeSelector
+from few.utils.utility import get_mismatch
+from few.utils.ylm import GetYlms
+from few.waveform import FastSchwarzschildEccentricFluxBicubic
 
 
-class ModeSelectorTest(unittest.TestCase):
+class ModeSelectorTest(FewBackendTest):
+    @classmethod
+    def name(self) -> str:
+        return "ModeSelector"
+
+    @classmethod
+    def parallel_class(self):
+        return FastSchwarzschildEccentricFluxBicubic
+
     def test_mode_selector(self):
         # first, lets get amplitudes for a trajectory
         traj = EMRIInspiral(func=SchwarzEccFlux)
@@ -106,7 +105,7 @@ class ModeSelectorTest(unittest.TestCase):
 
         # noise_weighted_mode_selector_kwargs = dict(sensitivity_fn=sens_fn)
 
-        few_base = FastSchwarzschildEccentricFluxBicubic(force_backend=best_backend)
+        few_base = FastSchwarzschildEccentricFluxBicubic(force_backend=self.backend)
 
         M = 1e6
         mu = 1e1
@@ -126,10 +125,10 @@ class ModeSelectorTest(unittest.TestCase):
             M, mu, p0, e0, theta, phi, dist, dt=dt, T=T, mode_selection=mode_selection
         )
 
-        get_logger().info(
+        self.logger.info(
             "  mismatch: {}".format(
                 mismatch := get_mismatch(
-                    wave_base, wave_weighted, use_gpu=best_backend.uses_gpu
+                    wave_base, wave_weighted, use_gpu=self.backend.uses_gpu
                 )
             )
         )

--- a/tests/test_mode_summation.py
+++ b/tests/test_mode_summation.py
@@ -1,39 +1,43 @@
-import unittest
 import numpy as np
-
-from few.summation.interpolatedmodesum import CubicSplineInterpolant, InterpolatedModeSum
 from scipy.interpolate import CubicSpline, interp1d
+
 from few.summation.directmodesum import DirectModeSum
+from few.summation.interpolatedmodesum import (
+    CubicSplineInterpolant,
+    InterpolatedModeSum,
+)
+from few.tests.base import FewBackendTest
 from few.trajectory.inspiral import EMRIInspiral
-from few.utils.globals import get_logger, get_first_backend
 from few.utils.constants import YRSID_SI
 
-few_logger = get_logger()
 
-best_backend = get_first_backend(InterpolatedModeSum.supported_backends())
-few_logger.warning(
-    "Mode-summation test is running with backend '{}'".format(best_backend.name)
-)
+class CubicSplineTest(FewBackendTest):
+    @classmethod
+    def name(self) -> str:
+        return "Mode-summation (CubicSpline)"
 
-class CubicSplineTest(unittest.TestCase):
+    @classmethod
+    def parallel_class(self):
+        return InterpolatedModeSum
+
     def test_cubic_spline(self):
         # check that the cubic spline correctly interpolates test functions
         t_test = np.linspace(0, 100, 1000)
         f_test = np.vstack((np.cos(t_test), np.sin(t_test)))
-        few_spl = CubicSplineInterpolant(t_test, f_test, force_backend=best_backend)
+        few_spl = CubicSplineInterpolant(t_test, f_test, force_backend=self.backend)
         scipy_spl = CubicSpline(t_test, f_test, axis=-1)
 
         # first check the knots are returned
         few_eval = few_spl(t_test)
-        if best_backend.uses_gpu:
+        if self.backend.uses_gpu:
             few_eval = few_eval.get()
         np.testing.assert_allclose(few_eval, f_test, rtol=1e-10)
-        
+
         # check that derivatives agree with scipy on the knots
-        for deriv_order in range(1,4):
+        for deriv_order in range(1, 4):
             few_eval = few_spl(t_test, deriv_order=deriv_order)
             scipy_eval = scipy_spl(t_test, nu=deriv_order)
-            if best_backend.uses_gpu:
+            if self.backend.uses_gpu:
                 few_eval = few_eval.get()
             np.testing.assert_allclose(few_eval, scipy_eval, rtol=1e-10)
 
@@ -43,39 +47,60 @@ class CubicSplineTest(unittest.TestCase):
         for deriv_order in range(4):
             few_eval = few_spl(t_eval, deriv_order=deriv_order)
             scipy_eval = scipy_spl(t_eval, nu=deriv_order)
-            if best_backend.uses_gpu:
+            if self.backend.uses_gpu:
                 few_eval = few_eval.get()
             np.testing.assert_allclose(few_eval, scipy_eval, rtol=1e-10)
 
 
-class SummationTest(unittest.TestCase):
+class SummationTest(FewBackendTest):
+    @classmethod
+    def name(self) -> str:
+        return "Mode-summation (Summation)"
+
+    @classmethod
+    def parallel_class(self):
+        return InterpolatedModeSum
+
     def test_interpolated_mode_sum(self):
         # check that the interpolatedmodesum accurately computes a dummy case
-        summation = InterpolatedModeSum(force_backend=best_backend)
+        summation = InterpolatedModeSum(force_backend=self.backend)
 
         # interpolatedmodesum expects 8th-order phase coefficients of a particular form
         # the easiest way to obtain these is to just evolve a 0PA trajectory
         # in the future when our integrator is fully stand-alone this can be generalised
         traj_module = EMRIInspiral(func="KerrEccEqFlux")
-        traj = traj_module(1e6, 1e1, 0.4, 20., 0.6, 1., T=0.1, err=1e-15)
+        _traj = traj_module(1e6, 1e1, 0.4, 20.0, 0.6, 1.0, T=0.1, err=1e-15)
         t_spl = traj_module.inspiral_generator.integrator_t_cache
-        coeff_spl = traj_module.inspiral_generator.integrator_spline_coeff[:,[3,5],:] / (1e1 / 1e6)
+        coeff_spl = traj_module.inspiral_generator.integrator_spline_coeff[
+            :, [3, 5], :
+        ] / (1e1 / 1e6)
 
         t_eval = np.linspace(0, t_spl[-1], 10001)
         dt = t_eval[1] - t_eval[0]
-        phases_eval = traj_module.inspiral_generator.eval_integrator_spline(t_eval)[:,[3,5]].T
+        phases_eval = traj_module.inspiral_generator.eval_integrator_spline(t_eval)[
+            :, [3, 5]
+        ].T
 
         # now we make up the rest
         num_modes = 10
 
         # dummy amplitudes: linearly ramping in real and imaginary part
-        amp_temp = np.linspace(np.random.uniform(-1, 1, (2, num_modes)), np.random.uniform(-1, 1, (2,num_modes)), t_eval.size, axis=-1)
-        amplitude = (amp_temp[0] + 1j*amp_temp[1]).T
+        amp_temp = np.linspace(
+            np.random.uniform(-1, 1, (2, num_modes)),
+            np.random.uniform(-1, 1, (2, num_modes)),
+            t_eval.size,
+            axis=-1,
+        )
+        amplitude = (amp_temp[0] + 1j * amp_temp[1]).T
 
         # we need to provide these values at the spline knots for InterpolatedModeSum
         # easy to do here as we are just ramping them linearly
-        amplitude_spl_temp = interp1d(t_eval, amp_temp, axis=-1, kind='linear', assume_sorted=True)(t_spl)
-        amplitude_spl = summation.xp.asarray((amplitude_spl_temp[0] + 1j*amplitude_spl_temp[1]).T)
+        amplitude_spl_temp = interp1d(
+            t_eval, amp_temp, axis=-1, kind="linear", assume_sorted=True
+        )(t_spl)
+        amplitude_spl = summation.xp.asarray(
+            (amplitude_spl_temp[0] + 1j * amplitude_spl_temp[1]).T
+        )
 
         # dummy mode indices
         l_arr = np.ones(num_modes) * 2  # not used in this fictitious summation
@@ -84,10 +109,13 @@ class SummationTest(unittest.TestCase):
 
         # dummy 'spherical harmonics'
         ylms = summation.xp.ones(2 * num_modes)
-        ylms[num_modes:] = 0   # disable the mode symmetry
+        ylms[num_modes:] = 0  # disable the mode symmetry
 
         # perform the summation manually
-        mode_phase_values = phases_eval[0,:,None] * m_arr[None,:] + phases_eval[1,:,None] * n_arr[None,:]
+        mode_phase_values = (
+            phases_eval[0, :, None] * m_arr[None, :]
+            + phases_eval[1, :, None] * n_arr[None, :]
+        )
         phasors = amplitude * np.exp(-1j * mode_phase_values)
         manual_sum = phasors.sum(-1)
 
@@ -95,10 +123,20 @@ class SummationTest(unittest.TestCase):
         m_arr = summation.xp.asarray(m_arr)
         n_arr = summation.xp.asarray(n_arr)
 
+        few_sum = summation(
+            summation.xp.asarray(t_spl),
+            amplitude_spl,
+            ylms,
+            t_spl,
+            coeff_spl,
+            l_arr,
+            m_arr,
+            n_arr,
+            T=t_spl[-1] / YRSID_SI,
+            dt=dt,
+        )
 
-        few_sum = summation(summation.xp.asarray(t_spl), amplitude_spl, ylms, t_spl, coeff_spl, l_arr, m_arr, n_arr, T=t_spl[-1] / YRSID_SI, dt=dt)
-
-        if best_backend.uses_gpu:
+        if self.backend.uses_gpu:
             few_sum = few_sum.get()
 
         # the following leads to an error on linux systems for some reason
@@ -106,21 +144,25 @@ class SummationTest(unittest.TestCase):
 
         np.testing.assert_allclose(manual_sum[:-1], few_sum[:-1], rtol=1e-8)
 
-
     def test_direct_mode_sum(self):
         # check that the directmodesum accurately computes a dummy case
-        summation = DirectModeSum(force_backend=best_backend)
+        summation = DirectModeSum(force_backend=self.backend)
 
         t_eval = np.linspace(0, 1000, 10001)
 
         num_modes = 10
         # dummy amplitudes: linearly ramping in real and imaginary part
-        amp_temp = np.linspace(np.random.uniform(-1, 1, (2, num_modes)), np.random.uniform(-1, 1, (2,num_modes)), t_eval.size, axis=-1)
-        amplitude = (amp_temp[0] + 1j*amp_temp[1]).T
+        amp_temp = np.linspace(
+            np.random.uniform(-1, 1, (2, num_modes)),
+            np.random.uniform(-1, 1, (2, num_modes)),
+            t_eval.size,
+            axis=-1,
+        )
+        amplitude = (amp_temp[0] + 1j * amp_temp[1]).T
 
         # dummy phases: linear ramp
-        Phi_phi_temp = np.pi/3 + 1e-2 * t_eval
-        Phi_r_temp = np.pi/4 + 3e-3 * t_eval
+        Phi_phi_temp = np.pi / 3 + 1e-2 * t_eval
+        Phi_r_temp = np.pi / 4 + 3e-3 * t_eval
 
         phases_in = np.asarray([Phi_phi_temp, Phi_phi_temp.copy(), Phi_r_temp])
 
@@ -131,16 +173,21 @@ class SummationTest(unittest.TestCase):
 
         # dummy 'spherical harmonics'
         ylms = np.ones(2 * num_modes)
-        ylms[num_modes:] = 0   # disable the mode symmetry
+        ylms[num_modes:] = 0  # disable the mode symmetry
 
         # perform the summation manually
-        mode_phase_values = Phi_phi_temp[:,None] * m_arr[None,:] + Phi_r_temp[:,None] * n_arr[None,:]
+        mode_phase_values = (
+            Phi_phi_temp[:, None] * m_arr[None, :]
+            + Phi_r_temp[:, None] * n_arr[None, :]
+        )
         phasors = amplitude * np.exp(-1j * mode_phase_values)
         manual_sum = phasors.sum(-1)
 
-        few_sum = summation(t_eval, amplitude, ylms, t_eval, phases_in, l_arr, m_arr, n_arr)
+        few_sum = summation(
+            t_eval, amplitude, ylms, t_eval, phases_in, l_arr, m_arr, n_arr
+        )
 
-        if best_backend.uses_gpu:
+        if self.backend.uses_gpu:
             few_sum = few_sum.get()
 
         np.testing.assert_allclose(manual_sum, few_sum, rtol=1e-10)

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -21,6 +21,7 @@ class WaveformTest(FewBackendTest):
 
     def tearDown(self):
         del self.waveform_generator
+        super().tearDown()
 
     def test_sampling_variation(self):
         # parameters

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,21 +1,22 @@
 import numpy as np
 
-from few.waveform import FastKerrEccentricEquatorialFlux
+from few.tests.base import FewBackendTest
 from few.utils.utility import get_mismatch
-import unittest
-
-from few.utils.globals import get_logger, get_first_backend
-
-few_logger = get_logger()
-
-best_backend = get_first_backend(FastKerrEccentricEquatorialFlux.supported_backends())
-few_logger.warning("Physics Test is running with backend {}".format(best_backend.name))
+from few.waveform import FastKerrEccentricEquatorialFlux
 
 
-class WaveformTest(unittest.TestCase):
+class WaveformTest(FewBackendTest):
+    @classmethod
+    def name(self) -> str:
+        return "Physics"
+
+    @classmethod
+    def parallel_class(self):
+        return FastKerrEccentricEquatorialFlux
+
     def setUp(self):
         self.waveform_generator = FastKerrEccentricEquatorialFlux(
-            force_backend=best_backend
+            force_backend=self.backend
         )
 
     def tearDown(self):
@@ -42,7 +43,7 @@ class WaveformTest(unittest.TestCase):
         ]
 
         # these two waveforms should be identical once resampled to the same time axis
-        mm = get_mismatch(wave1, wave2[::2], use_gpu=best_backend.uses_gpu)
+        mm = get_mismatch(wave1, wave2[::2], use_gpu=self.backend.uses_gpu)
         assert mm < 1e-14, (
             f"Waveforms not invariant under a change of sampling rate with mismatch {mm}."
         )
@@ -51,11 +52,11 @@ class WaveformTest(unittest.TestCase):
             :1000
         ]
         wave2 = self.waveform_generator(
-            M, mu, a, p0, e0, xI, theta, phi, T = 2*T, dt=10.0
+            M, mu, a, p0, e0, xI, theta, phi, T=2 * T, dt=10.0
         )[:1000]
 
         # these two waveforms should be identical once resampled to the same time axis
-        mm = get_mismatch(wave1, wave2, use_gpu=best_backend.uses_gpu)
+        mm = get_mismatch(wave1, wave2, use_gpu=self.backend.uses_gpu)
         assert mm < 1e-14, (
             f"Waveforms not invariant under a change of duration with mismatch {mm}."
         )
@@ -84,7 +85,7 @@ class WaveformTest(unittest.TestCase):
         )[:1000]
 
         # these two waveforms should be identical up to a rescailing of the time axis
-        mm = get_mismatch(wave1, wave2[::2], use_gpu=best_backend.uses_gpu)
+        mm = get_mismatch(wave1, wave2[::2], use_gpu=self.backend.uses_gpu)
         assert mm < 1e-14, (
             f"Waveforms not invariant under a rescaling of total mass and coordinate time with mismatch {mm}."
         )
@@ -105,7 +106,7 @@ class WaveformTest(unittest.TestCase):
         wave2 = self.waveform_generator(M, mu, a, p0, e0, -xI, theta, phi, T=T, dt=10.0)
 
         # these two waveforms should be identical as they represent the same physical system
-        mm = get_mismatch(wave1, wave2.conj(), use_gpu=best_backend.uses_gpu)
+        mm = get_mismatch(wave1, wave2.conj(), use_gpu=self.backend.uses_gpu)
         assert mm < 1e-13, (
             f"Schwarzschild waveforms not identical under a sign-flip of xI with mismatch {mm}."
         )
@@ -116,7 +117,7 @@ class WaveformTest(unittest.TestCase):
         wave2 = self.waveform_generator(M, mu, a, p0, e0, -xI, theta, phi, T=T, dt=10.0)
 
         # these two waveforms should be identical as they represent (essentially) the same physical system
-        mm = get_mismatch(wave1, wave2.conj(), use_gpu=best_backend.uses_gpu)
+        mm = get_mismatch(wave1, wave2.conj(), use_gpu=self.backend.uses_gpu)
         assert mm < 1e-13, (
             f"Prograde-retrograde waveforms not convergent with mismatch {mm}."
         )
@@ -130,7 +131,7 @@ class WaveformTest(unittest.TestCase):
         )
 
         # these two waveforms should be identical as they represent the same physical system
-        mm = get_mismatch(wave1, wave2.conj(), use_gpu=best_backend.uses_gpu)
+        mm = get_mismatch(wave1, wave2.conj(), use_gpu=self.backend.uses_gpu)
         assert mm < 1e-13, (
             f"Waveforms not convergent under joint sign-flip of a and xI with mismatch {mm}."
         )
@@ -138,7 +139,7 @@ class WaveformTest(unittest.TestCase):
         wave3 = self.waveform_generator(M, mu, -a, p0, e0, xI, theta, phi, T=T, dt=10.0)
 
         # these waveforms should greatly differ
-        assert get_mismatch(wave1, wave3, use_gpu=best_backend.uses_gpu) > 1e-5, (
+        assert get_mismatch(wave1, wave3, use_gpu=self.backend.uses_gpu) > 1e-5, (
             "Waveforms not divergent under a sign-flip of xI."
         )
 
@@ -178,7 +179,7 @@ class WaveformTest(unittest.TestCase):
         )
 
         assert (
-            get_mismatch(wave1, wave2.conj(), use_gpu=best_backend.uses_gpu) < 1e-14
+            get_mismatch(wave1, wave2.conj(), use_gpu=self.backend.uses_gpu) < 1e-14
         ), "Even ell-mode waveform not convergent under a parity transformation."
 
         # choose modes with odd m
@@ -202,7 +203,7 @@ class WaveformTest(unittest.TestCase):
         )
 
         assert (
-            get_mismatch(wave1, -wave2.conj(), use_gpu=best_backend.uses_gpu) < 1e-14
+            get_mismatch(wave1, -wave2.conj(), use_gpu=self.backend.uses_gpu) < 1e-14
         ), "Odd ell-mode waveform not convergent under a parity transformation."
 
     def test_distance_scaling(self):
@@ -223,7 +224,7 @@ class WaveformTest(unittest.TestCase):
         wave2 = self.waveform_generator(
             M, mu, a, p0, e0, xI, theta, phi, T=T, dt=10.0, dist=2.0
         )
-        mm = get_mismatch(wave1, wave2 * 2, use_gpu=best_backend.uses_gpu)
+        mm = get_mismatch(wave1, wave2 * 2, use_gpu=self.backend.uses_gpu)
         assert mm < 1e-14, (
             f"Waveform not invariant under a rescaling of luminosity distance with mismatch {mm}."
         )

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,23 +1,31 @@
-import unittest
-
-from few.utils.utility import ELQ_to_pex,get_kerr_geo_constants_of_motion,get_mu_at_t,get_p_at_t,get_separatrix, get_fundamental_frequencies
+from few.tests.base import FewTest
 from few.trajectory.inspiral import EMRIInspiral
-from few.utils.constants import YRSID_SI
 from few.trajectory.ode import KerrEccEqFlux
-
-traj_module = EMRIInspiral(func=KerrEccEqFlux)
-
-from few.utils.globals import get_logger, get_first_backend
-
-few_logger = get_logger()
-
-few_logger.warning(
-    "Utility tests are running"
+from few.utils.constants import YRSID_SI
+from few.utils.utility import (
+    ELQ_to_pex,
+    get_fundamental_frequencies,
+    get_kerr_geo_constants_of_motion,
+    get_mu_at_t,
+    get_p_at_t,
+    get_separatrix,
 )
-class UtilityTest(unittest.TestCase):
+
+
+class UtilityTest(FewTest):
+    @classmethod
+    def name(self) -> str:
+        return "Utility"
+
+    def setUp(self):
+        self.traj_module = EMRIInspiral(func=KerrEccEqFlux)
+
+    def tearDown(self):
+        del self.traj_module
+
     def test_Constants_of_Motion(self):
         a = 0.9
-        p = 10.
+        p = 10.0
         e = 0.3
         x = 0.5
 
@@ -33,24 +41,28 @@ class UtilityTest(unittest.TestCase):
         m1 = 1e6
 
         a = 0.9
-        p0 = 10.
+        p0 = 10.0
         e0 = 0.3
-        x0 = 1.
+        x0 = 1.0
 
         traj_args = [m1, a, p0, e0, x0]
         traj_kwargs = {}
         index_of_mu = 1
 
-        t_out = 1.
+        t_out = 1.0
 
-        m2 = get_mu_at_t(traj_module,t_out,traj_args,index_of_mu=index_of_mu,traj_kwargs=traj_kwargs)
-
-
+        m2 = get_mu_at_t(
+            self.traj_module,
+            t_out,
+            traj_args,
+            index_of_mu=index_of_mu,
+            traj_kwargs=traj_kwargs,
+        )
 
         traj_args = [m1, m2, a, p0, e0, x0]
 
-        t, p, e, xI, Phi_phi, Phi_theta, Phi_r = traj_module(*traj_args, T=t_out)
-        diff = 1 - t[-1]/ (t_out*YRSID_SI)
+        t, p, e, xI, Phi_phi, Phi_theta, Phi_r = self.traj_module(*traj_args, T=t_out)
+        diff = 1 - t[-1] / (t_out * YRSID_SI)
 
         self.assertLess(abs(diff), 1e-10)
 
@@ -59,74 +71,76 @@ class UtilityTest(unittest.TestCase):
         m2 = 10
         a = 0.9
         e0 = 0.3
-        x0 = 1.
+        x0 = 1.0
 
-        traj_args = [m1,m2,a, e0, x0]
+        traj_args = [m1, m2, a, e0, x0]
         traj_kwargs = {}
         index_of_p = 3
 
-        t_out = 1.
+        t_out = 1.0
 
-        p0 = get_p_at_t(traj_module,t_out,traj_args,index_of_p=index_of_p,traj_kwargs=traj_kwargs)
-
-
+        p0 = get_p_at_t(
+            self.traj_module,
+            t_out,
+            traj_args,
+            index_of_p=index_of_p,
+            traj_kwargs=traj_kwargs,
+        )
 
         traj_args = [m1, m2, a, p0, e0, x0]
 
-        t, p, e, xI, Phi_phi, Phi_theta, Phi_r = traj_module(*traj_args, T=t_out)
-        diff = 1 - t[-1]/ (t_out*YRSID_SI)
+        t, p, e, xI, Phi_phi, Phi_theta, Phi_r = self.traj_module(*traj_args, T=t_out)
+        diff = 1 - t[-1] / (t_out * YRSID_SI)
 
         self.assertLess(abs(diff), 1e-10)
+
     def test_get_separatrix_generic(self):
-        
-            a= 0.9
-            e = 0.3
-            x = 0.5
+        a = 0.9
+        e = 0.3
+        x = 0.5
 
-            p_sep = get_separatrix(a, e, x)
+        p_sep = get_separatrix(a, e, x)
 
-            p_sep_KerrGeo = 4.100908189793339
+        p_sep_KerrGeo = 4.100908189793339
 
-            diff = p_sep_KerrGeo - p_sep
+        diff = p_sep_KerrGeo - p_sep
 
-            self.assertLess(abs(diff), 1e-14)
+        self.assertLess(abs(diff), 1e-14)
+
     def test_get_separatrix_Schwarz(self):
-        
-            a= 0.0
-            e = 0.5
-            x = 0.5
+        a = 0.0
+        e = 0.5
+        x = 0.5
 
-            p_sep = get_separatrix(a, e, x)
+        p_sep = get_separatrix(a, e, x)
 
-            p_sep_KerrGeo = 4.100908189793339
+        # p_sep_KerrGeo = 4.100908189793339
 
-            diff = p_sep - (6.+ 2.*e)
+        diff = p_sep - (6.0 + 2.0 * e)
 
-            self.assertLess(abs(diff), 1e-14)
+        self.assertLess(abs(diff), 1e-14)
 
     def test_get_fundamental_frequencies(self):
-        
-            a= 0.9
-            e = 0.3
-            p = 10.
-            x = 0.5
+        a = 0.9
+        e = 0.3
+        p = 10.0
+        x = 0.5
 
-            OmegaPhi, OmegaTheta, OmegaR = get_fundamental_frequencies(a, p, e, x)
-            
-            # Taken from the KerrGeodesics Mathematica package
-            OmegaPhiKerrGeo, OmegaThetaKerrGeo, OmegaRKerrGeo = 0.028478026708595002, 0.027032450748133277, 0.020053165349083846 
+        OmegaPhi, OmegaTheta, OmegaR = get_fundamental_frequencies(a, p, e, x)
 
-            [abs(OmegaPhi - OmegaPhiKerrGeo), abs(OmegaTheta - OmegaThetaKerrGeo), abs(OmegaR - OmegaRKerrGeo)]
+        # Taken from the KerrGeodesics Mathematica package
+        OmegaPhiKerrGeo, OmegaThetaKerrGeo, OmegaRKerrGeo = (
+            0.028478026708595002,
+            0.027032450748133277,
+            0.020053165349083846,
+        )
 
-            self.assertLess(abs(OmegaPhi - OmegaPhiKerrGeo), 1e-13)
-            self.assertLess(abs(OmegaTheta - OmegaThetaKerrGeo), 1e-13)
-            self.assertLess(abs(OmegaR - OmegaRKerrGeo), 1e-13)
+        [
+            abs(OmegaPhi - OmegaPhiKerrGeo),
+            abs(OmegaTheta - OmegaThetaKerrGeo),
+            abs(OmegaR - OmegaRKerrGeo),
+        ]
 
-    
-
-    
-
-    
-
-
-
+        self.assertLess(abs(OmegaPhi - OmegaPhiKerrGeo), 1e-13)
+        self.assertLess(abs(OmegaTheta - OmegaThetaKerrGeo), 1e-13)
+        self.assertLess(abs(OmegaR - OmegaRKerrGeo), 1e-13)

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -22,6 +22,7 @@ class UtilityTest(FewTest):
 
     def tearDown(self):
         del self.traj_module
+        super().tearDown()
 
     def test_Constants_of_Motion(self):
         a = 0.9

--- a/tests/test_ylm.py
+++ b/tests/test_ylm.py
@@ -1,16 +1,35 @@
-import unittest
 import numpy as np
-from few.utils.ylm import GetYlms
-from few.utils.globals import get_logger, get_first_backend
 
-class ModuleTest(unittest.TestCase):
+from few.tests.base import FewTest
+from few.utils.ylm import GetYlms
+
+
+class ModuleTest(FewTest):
+    @classmethod
+    def name(self) -> str:
+        return "YLM"
+
     def testYlms(self):
         ylm = GetYlms()
 
         # int inputs
-        self.assertAlmostEqual(ylm(2, 2, 1., 0.3), 0.30878955111651396+0.2112542979501157j)
-        self.assertAlmostEqual(ylm(4, -3, 2., 0.1), 0.11564282752815112-0.03577251856181077j)
+        self.assertAlmostEqual(
+            ylm(2, 2, 1.0, 0.3), 0.30878955111651396 + 0.2112542979501157j
+        )
+        self.assertAlmostEqual(
+            ylm(4, -3, 2.0, 0.1), 0.11564282752815112 - 0.03577251856181077j
+        )
 
         # array inputs for l, m
-        ylms = ylm(np.array([5, 4]), np.array([2, -1]), 1., 0.3)
-        self.assertTrue(np.allclose(ylms, np.array([-0.12267424266796564-0.08392596484459626j, 0.37975916907591606-0.11747327711681067j])))
+        ylms = ylm(np.array([5, 4]), np.array([2, -1]), 1.0, 0.3)
+        self.assertTrue(
+            np.allclose(
+                ylms,
+                np.array(
+                    [
+                        -0.12267424266796564 - 0.08392596484459626j,
+                        0.37975916907591606 - 0.11747327711681067j,
+                    ]
+                ),
+            )
+        )


### PR DESCRIPTION
This PR does three things:

## Improve conversion logic between `np.ndarray` and `cp.ndarray`

While working on #64 , I noticed that some function had complicated logics to detect whether they received `np.ndarray` or `cp.ndarray` and convert them into the expected type. In some cases, the current logic could not even work (it had unreachable code branches).

This PR fixes both `get_overlap` and some functions in `fdutils` to simplify and fix those parts of the code.

## Improve implementation of tests

I'm doing some memory profiling of tests and was bothered by the fact that when we start test executions, all tests simultaneously log a `Test starting with backend '...'` message even though the test were not actually starting at that point. I wanting to know at what point exactly each test was starting.

I thus implemented two new base classes for FEW tests so fix that issue and detect correctly when tests are actually running. I also used that opportunity to remove completely boilerplate code at the top of test files to detect the test backends.

Now, a test that does not rely on a specific backend must derive from the `FewTest` class and declare its own name through the `name` class method. See for example `test_utility`:

```python
from few.tests.base import FewTest

class UtilityTest(FewTest):
    @classmethod
    def name(self) -> str:
        return "Utility"

    def test_Constants_of_Motion(self):
        ...
```

At execution, the log will look like:

```
Test 'Utility' is starting.
......
  Test 'Utility': done.
```

If a test needs to have a backend associated, it must derive from `FewBackendTest` and declare both its name, and its `parallel_class` (a class deriving from `ParallelModuleBase`, the test will have, as associated backend, the best available backend supported by that class). For instance, in `test_kerr.py`, the file header used to contain

```python
best_backend = get_first_backend(FastKerrEccentricEquatorialFlux.supported_backends())
```

This is now replaced by:

```python
from few.tests.base import FewBackendTest

class KerrWaveformTest(FewBackendTest):
    @classmethod
    def name(self) -> str:
        return "Kerr"

    @classmethod
    def parallel_class(self):
        return FastKerrEccentricEquatorialFlux

    def test_Kerr_vs_Schwarzchild(self):
        ...
```

which automatically yields the following log:

```
Test 'Kerr' is starting.
  Test 'Kerr': running with backend 'cpu'
..
  Test 'Kerr': done.
```

## Force memory collection at the end of each test

Since runners are memory limited, I force `gc.collect()` operation at the end of each test to aggressively get back memory and limit the total usage as much as possible.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--67.org.readthedocs.build/en/67/

<!-- readthedocs-preview fastemriwaveforms end -->