### PR TITLE
Improve control over workflows execution

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   documentation-links:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.base.repo.full_name == 'BlackHolePerturbationToolkit/FastEMRIWaveforms'
     steps:
       - uses: readthedocs/actions/preview@v1
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,14 +1,42 @@
 name: Publish documentation to GitHub Pages
 on:
   push:
-    tags:
-      - 'v*.*.**'
 jobs:
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.select.outputs.build }}
+      publish: ${{ steps.select.outputs.publish }}
+    steps:
+      - name: initialize
+        run: |
+          echo "FEWPAGE_BUILD=false" >> "$GITHUB_ENV"
+          echo "FEWPAGE_PUBLISH=false" >> "$GITHUB_ENV"
+      - name: build on commit message
+        if: contains(github.event.head_commit.message, '[ci:build-pages]')
+        run: |
+          echo "FEWPAGE_BUILD=true" >> "$GITHUB_ENV"
+      - name: build and publish on tag 'v*'
+        if: startsWith(github.event.ref, 'refs/tags/v')
+        run: |
+          echo "FEWPAGE_BUILD=true" >> "$GITHUB_ENV"
+          echo "FEWPAGE_PUBLISH=true" >> "$GITHUB_ENV"
+      - name: output results
+        id: select
+        run: |
+          echo "build=$FEWPAGE_BUILD" >> $GITHUB_OUTPUT
+          echo "publish=$FEWPAGE_PUBLISH" >> $GITHUB_OUTPUT
   build_doc:
-    name: Build and upload documentation
-    runs-on: "ubuntu-24.04-arm"
+    name: Build documentation
+    runs-on: "ubuntu-24.04"
+    needs:
+      - select
+    if: needs.select.outputs.build == 'true'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -16,10 +44,10 @@ jobs:
         uses: ConorMacBride/install-package@v1
         with:
           apt: liblapacke-dev pandoc
-      - name: Update version scheme
-        run: |
-          sed -i 's|version_scheme = "no-guess-dev"|version_scheme = "only-version"|g' pyproject.toml
-          sed -i 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
+      # - name: Update version scheme
+      #   run: |
+      #     sed -i 's|version_scheme = "no-guess-dev"|version_scheme = "only-version"|g' pyproject.toml
+      #     sed -i 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
       - name: Install bare package
         run: |
           python -m pip install '.[doc, testing]' \
@@ -33,7 +61,7 @@ jobs:
           path: local_cache
           key: ${{ hashFiles('src/few/files/registry.yml') }}
       - name: Export configuration options to force using prefetched cache of files
-        if: ${{ steps.restore_cache.outputs.cache-hit == 'true' }}
+        if: steps.restore_cache.outputs.cache-hit == 'true'
         run: |
           echo "FEW_FILE_ALLOW_DOWNLOAD=no" >> "$GITHUB_ENV"
           echo "FEW_FILE_EXTRA_PATHS=$(pwd)/local_cache" >> "$GITHUB_ENV"
@@ -58,7 +86,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build_doc
+    needs:
+      - build_doc
+      - select
+    if: needs.select.outputs.publish == 'true'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           echo "FEWWHL_BUILD=true" >> "$GITHUB_ENV"
           echo "FEWWHL_PUBLISH=true" >> "$GITHUB_ENV"
       - name: add core-suffix on non-official repo
-        if: ${{ github.event.repository.full_name != 'BlackHolePerturbationToolkit/FastEMRIWaveforms' }}
+        if: github.event.repository.full_name != 'BlackHolePerturbationToolkit/FastEMRIWaveforms'
         run: |
           echo "FEWWHL_CORE_SUFFIX=true" >> "$GITHUB_ENV"
       - name: output results

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "build=$FEWWHL_BUILD" >> $GITHUB_OUTPUT
           echo "publish=$FEWWHL_PUBLISH" >> $GITHUB_OUTPUT
-          echo "core-suffix=$FEWWHFEWWHL_CORE_SUFFIXL_BUILD" >> $GITHUB_OUTPUT
+          echo "core-suffix=$FEWWHL_CORE_SUFFIX" >> $GITHUB_OUTPUT
   build:
     name: few-${{ matrix.release }} on ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
@@ -150,6 +150,7 @@ jobs:
       # = IV. Build wheels  =
       # =====================
       - uses: fortran-lang/setup-fortran@v1
+        if: matrix.kind == 'core'
         id: setup-fortran
         with:
           compiler: gcc
@@ -245,7 +246,7 @@ jobs:
         run: |
           ls -al wheelhouse/*
       - name: Install twine from PyPI
-        uses: install-pinned/twine@e0e1034852ffdf3e7867300539b1065f1bff2a87 # 6.0.1
+        uses: install-pinned/twine@c7ca21f7f66fc895b73cba784dc1d0e302e3b4a3 # 6.1.0
       - name: Publish release distributions to registry
         env:
           TWINE_NON_INTERACTIVE: "yes"

--- a/src/few/trajectory/integrate.py
+++ b/src/few/trajectory/integrate.py
@@ -209,7 +209,7 @@ class Integrate:
     def tune_initial_step_size(self, t0: float, y0: np.ndarray, h_max: float) -> float:
         """Tune the initial step size of the integrator if using adaptive stepping.
 
-        Adapted from SciPy: https://github.com/scipy/scipy/blob/main/scipy/integrate/_ivp/common.py#L68
+        Adapted from scipy.integrate._ivp.common.select_initial_step
 
         Args:
             t0: Initial time.


### PR DESCRIPTION
I'm currently trying to figure out how to better control GHA workflows and took the opportunity to improve existing ones.

This PR does the following things:

- Disable the RTD action which edits a PR when we are not on the main `BlackHolePerturbationToolkit/FastEMRIWaveforms` repository (this will not apply to the current PR which will still be updated with a bogus RTD link since the workflow is triggered by the PR `base` branch, not the `head` one)
- The `publish` workflow can now be triggered by a commit whose message contains `[ci:build-wheels]`. In this case, wheels are built but not uploaded to PyPI. I also removed the dependency on the `pypiconf` environment for the build step (previously we had to authorise manually both the build and the upload steps independently...). If is also triggered on tags of format `v*`
- The `pages` workflow can similarly be triggered by a commit whose message contains `[ci:build-pages]` or by a tag `v*`. When triggered by the commit message, the doc build steps are executed (internal links are checked, HTML doc is produced), but the documentation is not uploaded to github pages (this is reserved to the tag trigger).

 I will soon implement similar logics to the `run-tests` workflow to choose between three modes (`light`/`medium`/`full`) to reduce the weight and duration of tests execution in most cases but still allow for full test suite execution on release candidates. I'll open a discussion on this topic before implementing the details.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--70.org.readthedocs.build/en/70/

<!-- readthedocs-preview fastemriwaveforms end -->