### PR TITLE
Implement distance to boundary for Kerr model

### DIFF
--- a/src/few/trajectory/ode/flux.py
+++ b/src/few/trajectory/ode/flux.py
@@ -479,10 +479,6 @@ class KerrEccEqFlux(ODEBase):
         p_sep_min_buffer = get_separatrix(a_in, 0, 1) + self.separatrix_buffer_dist
         if p < p_sep_min_buffer:
             raise ValueError(f"Interpolation: p out of bounds. Must be greater than innermost stable circular orbit + buffer = {p_sep_min_buffer}.")
-        
-        z = z_of_a(a_in)
-        e_max_min = e_of_uwz_flux(0, 1, z)
-        p_sep_max_min = get_separatrix(a_in, e_max_min, 1)
 
         p_min = self._min_p(EMAX, x, a)
         if p > p_min:
@@ -551,6 +547,21 @@ class KerrEccEqFlux(ODEBase):
         self.isvalid_a(a, a_buffer=a_buffer)
         pmin, pmax = self.bounds_p(e, x, a, p_buffer=p_buffer)
         assert (p >= pmin and p <= pmax), f"Interpolation: p {p} out of bounds. Must be between {pmin} and {pmax}."
+
+    def distance_to_outer_boundary(self, y):
+        p, e, x = self.get_pex(y)
+
+        e_max = self._max_e(p, x, self.a)
+        dist_p = PMAX - p
+        dist_e = e_max - e
+
+        if dist_p < 0 or dist_e < 0:
+            mult = -1
+        else:
+            mult = 1
+
+        dist = mult * min(abs(dist_p), abs(dist_e))
+        return dist
 
     def interpolate_flux_grids(self, p: float, e: float, x: float = 1, a: float = 0, pLSO: Optional[float] = None) -> tuple[float]:
         if pLSO is None:

--- a/src/few/trajectory/ode/flux.py
+++ b/src/few/trajectory/ode/flux.py
@@ -552,8 +552,10 @@ class KerrEccEqFlux(ODEBase):
         p, e, x = self.get_pex(y)
 
         e_max = self._max_e(p, x, self.a)
-        dist_p = PMAX - p
-        dist_e = e_max - e
+
+        # Subtract a small value to avoid numerical issues at the boundary
+        dist_p = (PMAX - 1e-9) - p
+        dist_e = (e_max - 1e-9) - e
 
         if dist_p < 0 or dist_e < 0:
             mult = -1

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -149,6 +149,72 @@ class ModuleTest(FewTest):
                     msg=f"Failed for {p0=}, {e0=}, {a=}, {x0=}",
                 )
 
+    def test_backward_trajectory_termination_kerr(self):
+        self.logger.info("Testing kerr backward termination at grid boundaries")
+        
+        # Initialize trajectory class
+        traj = EMRIInspiral(func=KerrEccEqFlux)
+        
+        # Test parameters
+        m1 = 1e6
+        m2 = 10.
+        
+        # Test 1: Termination at e boundary
+        self.logger.info("Test 1: Termination at eccentricity boundary")
+        a = 0.5
+        x0 = 1.0
+        
+        # Start near the maximum eccentricity
+        p0 = 12.0
+        flux_obj = KerrEccEqFlux()
+        flux_obj.a = a
+        e_max = flux_obj._max_e(p0, x0, a)
+        e0 = e_max - 0.05
+        
+        backwards_kwargs = insp_kw.copy()
+        backwards_kwargs.update({
+            "integrate_backwards": True,
+            "T": 10.0,
+            "dt": 10.
+        })
+        
+        result = traj(m1, m2, a, p0, e0, x0, **backwards_kwargs)
+        final_e = result[2][-1]
+        
+        # Check that we're near the maximum eccentricity
+        flux_obj.a = a
+        e_max_final = flux_obj._max_e(result[1][-1], x0, a)
+        
+        self.assertAlmostEqual(
+            final_e, e_max_final, 
+            msg=f"Failed to reach e boundary. Final e={final_e}, max e={e_max_final}"
+        )
+        
+        # Test 2: Termination at p boundary
+        self.logger.info("Test 2: Termination at p boundary")
+        a = 0.0
+        e0 = 0.0
+        
+        # Start very close to PMAX
+        # PMAX = PMAX_REGIONB = 200
+        PMAX = 200
+        p0 = 199.5
+        
+        backwards_kwargs = insp_kw.copy()
+        backwards_kwargs.update({
+            "integrate_backwards": True,
+            "T": 10_000.,  # Much longer integration time
+            "dt": 10_000.  # Larger time step for slow evolution
+        })
+        
+        result = traj(m1, m2, a, p0, e0, x0, **backwards_kwargs)
+        final_p = result[1][-1]
+                
+        self.assertAlmostEqual(
+            final_p, PMAX,
+            msg=f"Failed to reach p boundary. Final p={final_p}, PMAX={PMAX}"
+        )
+
     def test_trajectory_ELQ_vs_pex(self):
         """
         This test computes the trajectory using the ELQ and pex flux conventions. It will then


### PR DESCRIPTION
- Added the distance_to_outer_boundary method to the KerrEccEqFlux class to gracefully terminate a backward integration when passing the grid boundary (structurally follows the implementation in SchwarzEccFlux).
- Removed some unused code in _max_e to prevent the unnecessary computation time.
- Introduced a new test to confirm this behaviour, explicitly testing both e and p boundaries.

Please let me know if anything is unclear, or needs tinkering.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--72.org.readthedocs.build/en/72/

<!-- readthedocs-preview fastemriwaveforms end -->