### PR TITLE
Fixes before the 2.0 release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           echo "FEWPAGE_BUILD=false" >> "$GITHUB_ENV"
           echo "FEWPAGE_PUBLISH=false" >> "$GITHUB_ENV"
-          echo "FEWPAGE_NOTEBOOK=never" >> "$GITHUB_ENV"
+          echo "FEWPAGE_NOTEBOOK=false" >> "$GITHUB_ENV"
       - name: build on commit message
         if: contains(github.event.head_commit.message, '[ci:build-pages]')
         run: |
@@ -21,7 +21,7 @@ jobs:
       - name: execute notebooks on request
         if: contains(github.event.head_commit.message, '[doc:run-notebooks]')
         run: |
-          echo "FEWPAGE_NOTEBOOK=always" >> "$GITHUB_ENV"
+          echo "FEWPAGE_NOTEBOOK=true" >> "$GITHUB_ENV"
       - name: build and publish on tag 'v*'
         if: startsWith(github.event.ref, 'refs/tags/v')
         run: |
@@ -76,10 +76,21 @@ jobs:
         run: |
           sphinx-build -M linkcheck docs/source docs/build_checklinks \
               --define nbsphinx_execute=never
+      - name: Run notebook examples
+        if: needs.select.outputs.notebooks == 'true'
+        run: |
+          jupyter nbconvert --execute --clear-output examples/Trajectory_tutorial.ipynb
+          jupyter nbconvert --execute --clear-output examples/Amplitude_tutorial.ipynb
+          jupyter nbconvert --execute --clear-output examples/modeselect.ipynb
+          jupyter nbconvert --execute --clear-output examples/modesummation.ipynb
+          jupyter nbconvert --execute --clear-output examples/cubicspline.ipynb
+          jupyter nbconvert --execute --clear-output examples/swsh.ipynb
+          jupyter nbconvert --execute --clear-output examples/utility.ipynb
+          jupyter nbconvert --execute --clear-output examples/waveform.ipynb
       - name: Build documentation
         run: |
           sphinx-build -M html docs/source docs/build \
-              --define nbsphinx_execute=${{ needs.select.outputs.notebooks }}
+              --define nbsphinx_execute=never
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,15 +7,21 @@ jobs:
     outputs:
       build: ${{ steps.select.outputs.build }}
       publish: ${{ steps.select.outputs.publish }}
+      notebooks: ${{ steps.select.outputs.notebooks }}
     steps:
       - name: initialize
         run: |
           echo "FEWPAGE_BUILD=false" >> "$GITHUB_ENV"
           echo "FEWPAGE_PUBLISH=false" >> "$GITHUB_ENV"
+          echo "FEWPAGE_NOTEBOOK=never" >> "$GITHUB_ENV"
       - name: build on commit message
         if: contains(github.event.head_commit.message, '[ci:build-pages]')
         run: |
           echo "FEWPAGE_BUILD=true" >> "$GITHUB_ENV"
+      - name: execute notebooks on request
+        if: contains(github.event.head_commit.message, '[doc:run-notebooks]')
+        run: |
+          echo "FEWPAGE_NOTEBOOK=always" >> "$GITHUB_ENV"
       - name: build and publish on tag 'v*'
         if: startsWith(github.event.ref, 'refs/tags/v')
         run: |
@@ -26,6 +32,7 @@ jobs:
         run: |
           echo "build=$FEWPAGE_BUILD" >> $GITHUB_OUTPUT
           echo "publish=$FEWPAGE_PUBLISH" >> $GITHUB_OUTPUT
+          echo "notebooks=$FEWPAGE_NOTEBOOK" >> $GITHUB_OUTPUT
   build_doc:
     name: Build documentation
     runs-on: "ubuntu-24.04"
@@ -72,7 +79,7 @@ jobs:
       - name: Build documentation
         run: |
           sphinx-build -M html docs/source docs/build \
-              --define nbsphinx_execute=never
+              --define nbsphinx_execute=${{ needs.select.outputs.notebooks }}
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           echo "FEWPAGE_BUILD=true" >> "$GITHUB_ENV"
           echo "FEWPAGE_PUBLISH=true" >> "$GITHUB_ENV"
+          echo "FEWPAGE_NOTEBOOK=true" >> "$GITHUB_ENV"
       - name: output results
         id: select
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,38 @@ jobs:
           echo "build=$FEWWHL_BUILD" >> $GITHUB_OUTPUT
           echo "publish=$FEWWHL_PUBLISH" >> $GITHUB_OUTPUT
           echo "core-suffix=$FEWWHL_CORE_SUFFIX" >> $GITHUB_OUTPUT
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.setuptools_scm.outputs.value }}
+    steps:
+      # =========================
+      # = I - Retrieve sources  =
+      # =========================
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      # ===================================
+      # = II - Prepare Python environment =
+      # ===================================
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: |
+          pip install setuptools_scm
+      # ========================
+      # = III - Detect version =
+      # ========================
+      - id: setuptools_scm
+        run: |
+          echo "value=$(python -m setuptools_scm)" >> $GITHUB_OUTPUT
   build:
     name: few-${{ matrix.release }} on ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     needs:
       - select
+      - version
     if: needs.select.outputs.build == 'true'
     strategy:
       fail-fast: false
@@ -100,9 +127,6 @@ jobs:
       # = I - Retrieve sources  =
       # =========================
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
       # ========================
       # = II - Update sources  =
       # ========================
@@ -110,7 +134,7 @@ jobs:
         run: |
           sed -i'' -e 's|version_scheme = "no-guess-dev"|version_scheme = "only-version"|g' pyproject.toml
           sed -i'' -e 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
-          sed -i'' -e 's|#@FALLBACK_VERSION@|fallback_version = "${{ github.ref_name }}"|g' pyproject.toml
+          sed -i'' -e 's|#@FALLBACK_VERSION@|fallback_version = "${{ needs.version.outputs.version }}"|g' pyproject.toml
       - name: Add release suffix to project name
         if: matrix.kind != 'core'
         run: |
@@ -128,11 +152,11 @@ jobs:
       - name: Add core project dependency on plugin
         if: matrix.kind != 'core' && needs.select.outputs.core-suffix == 'true'
         run: |
-          sed -i'' -e 's|#@DEPS_FEWCORE@|"fastemriwaveforms-cpu==${{ github.ref_name }}"|g' pyproject.toml
+          sed -i'' -e 's|#@DEPS_FEWCORE@|"fastemriwaveforms-cpu==${{ needs.version.outputs.version }}"|g' pyproject.toml
       - name: Add core project dependency on plugin
-        if: matrix.kind != 'core' && needs.select.outputs.core-suffix == 'true'
+        if: matrix.kind != 'core' && needs.select.outputs.core-suffix == 'false'
         run: |
-          sed -i'' -e 's|#@DEPS_FEWCORE@|"fastemriwaveforms==${{ github.ref_name }}"|g' pyproject.toml
+          sed -i'' -e 's|#@DEPS_FEWCORE@|"fastemriwaveforms==${{ needs.version.outputs.version }}"|g' pyproject.toml
       # Remove base sources from plugin wheels
       - name: Exclude core package from plugins
         if: matrix.kind != 'core'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
       - name: initialize
         run: |
           echo "FEWWHL_BUILD=false" >> "$GITHUB_ENV"
-          echo "FEWWHL_PUBLISH=false" >> "$GITHUB_ENV"
           echo "FEWWHL_CORE_SUFFIX=false" >> "$GITHUB_ENV"
+          echo "FEWWHL_PUBLISH=false" >> "$GITHUB_ENV"
       - name: build on commit message
         if: contains(github.event.head_commit.message, '[ci:build-wheels]')
         run: |
@@ -58,11 +58,17 @@ jobs:
       # ========================
       # = III - Detect version =
       # ========================
-      - id: setuptools_scm
+      - name: Update version scheme
+        run: |
+          sed -i'' -e 's|version_scheme = "no-guess-dev"|version_scheme = "only-version"|g' pyproject.toml
+          sed -i'' -e 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
+      - name: Detect current version
+        id: setuptools_scm
         run: |
           VERSION="$(python -m setuptools_scm)"
-          echo "Detected version: ${VERSION}"
+          echo "notice:: Detected version: ${VERSION}"
           echo "value=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version: ${VERSION}" >> $GITHUB_STEP_SUMMARY
   build:
     name: few-${{ matrix.release }} on ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
@@ -132,11 +138,6 @@ jobs:
       # ========================
       # = II - Update sources  =
       # ========================
-      - name: Update version scheme
-        run: |
-          sed -i'' -e 's|version_scheme = "no-guess-dev"|version_scheme = "only-version"|g' pyproject.toml
-          sed -i'' -e 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
-          sed -i'' -e 's|#@FALLBACK_VERSION@|fallback_version = "${{ needs.version.outputs.version }}"|g' pyproject.toml
       - name: Add release suffix to project name
         if: matrix.kind != 'core'
         run: |
@@ -193,6 +194,8 @@ jobs:
             cmake.define.FEW_WITH_GPU=OFF
             cmake.define.CMAKE_Fortran_COMPILER=${{ steps.setup-fortran.outputs.fc }}
           CIBW_TEST_COMMAND: python -m few.tests --disable testfile
+          CIBW_ENVIRONMENT: >
+            SETUPTOOLS_SCM_PRETEND_VERSION="${{ needs.version.outputs.version }}"
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_ver }}
       - name: Build core wheels (Linux)
         if: runner.os == 'Linux' && matrix.kind == 'core'
@@ -215,6 +218,7 @@ jobs:
             rm -Rf lapack
           CIBW_ENVIRONMENT: >
             PKG_CONFIG_PATH="/opt/lapack/lib64/pkgconfig/:${PKG_CONFIG_PATH}"
+            SETUPTOOLS_SCM_PRETEND_VERSION="${{ needs.version.outputs.version }}"
           CIBW_TEST_COMMAND: python -m few.tests --disable testfile
       - name: Build cuda plugin wheels (Linux)
         if: runner.os == 'Linux' && matrix.kind == 'cuda_plugin' && matrix.arch == 'x86_64'
@@ -241,6 +245,7 @@ jobs:
             CUDADIR=/usr/local/cuda
             CC=gcc
             CXX=g++
+            SETUPTOOLS_SCM_PRETEND_VERSION="${{ needs.version.outputs.version }}"
           CIBW_REPAIR_WHEEL_COMMAND: auditwheel repair -w {dest_dir} {wheel} --exclude "libcudart.so.${{ matrix.cuda_major }}" --exclude "libcusparse.so.${{ matrix.cuda_major }}" --exclude "libcublas.so.${{ matrix.cuda_major }}" --exclude "libnvJitLink.so.${{ matrix.cuda_major }}" --exclude "libcublasLt.so.${{ matrix.cuda_major }}"
       # =====================
       # = V. Upload wheels  =

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,9 @@ jobs:
       # ========================
       - id: setuptools_scm
         run: |
-          echo "value=$(python -m setuptools_scm)" >> $GITHUB_OUTPUT
+          VERSION="$(python -m setuptools_scm)"
+          echo "Detected version: ${VERSION}"
+          echo "value=${VERSION}" >> $GITHUB_OUTPUT
   build:
     name: few-${{ matrix.release }} on ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,8 +14,8 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import pathlib
 import os
+import pathlib
 
 import few
 
@@ -93,7 +93,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3.11", None),
 }
 
-linkcheck_ignore = [r"https://dx.doi.org/"]
+linkcheck_ignore = [r"https://dx.doi.org/", r"https://hpc.pages.cnes.fr/.*"]
 
 myst_heading_anchors = 2
 myst_url_schemes = {

--- a/docs/source/user/util.rst
+++ b/docs/source/user/util.rst
@@ -49,7 +49,7 @@ Elliptic integrals (Legendre and Carlson symmetric forms)
 PN Parameter Mapping Utilities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automodule:: few.utils.pn_map
+.. automodule:: few.utils.mappings.pn
     :members:
     :show-inheritance:
     :inherited-members:

--- a/examples/FastEMRIWaveforms_tutorial.ipynb
+++ b/examples/FastEMRIWaveforms_tutorial.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -44,7 +44,7 @@
     "    ELQ_to_pex,\n",
     "    )\n",
     "\n",
-    "from few.utils.pn_map import (\n",
+    "from few.utils.mappings.pn import (\n",
     "    xI_to_Y,\n",
     "    Y_to_xI\n",
     ")\n",
@@ -606,7 +606,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "few-venv",
    "language": "python",
    "name": "python3"
   },
@@ -620,7 +620,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/examples/example_pn5_add_phys_waveform.py
+++ b/examples/example_pn5_add_phys_waveform.py
@@ -14,7 +14,7 @@ from few.utils.baseclasses import *
 from few.trajectory.inspiral import EMRIInspiral
 from few.summation.aakwave import AAKSummation
 from few.utils.utility import get_mismatch, get_separatrix, _get_separatrix_kernel_inner, get_fundamental_frequencies, _KerrGeoCoordinateFrequencies_kernel_inner
-from few.utils.pn_map import Y_to_xI, _Y_to_xI_kernel_inner
+from few.utils.mappings.pn import Y_to_xI, _Y_to_xI_kernel_inner
 
 # define trajectory RHS class
 

--- a/examples/waveform.ipynb
+++ b/examples/waveform.ipynb
@@ -74,7 +74,7 @@
                 "\n",
                 "# Trick to share waveform generator between both few_gen and td_gen (and reduce\n",
                 "# memory consumption)\n",
-                "td_gen.waveform_generator = few_gen.waveform_generator\n",
+                "td_gen.waveform_generator.amplitude_generator = few_gen.waveform_generator.amplitude_generator\n",
                 "\n",
                 "import gc\n",
                 "gc.collect()"

--- a/examples/waveform.ipynb
+++ b/examples/waveform.ipynb
@@ -52,7 +52,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 2,
+            "execution_count": null,
             "id": "15c08219-56eb-430d-b19e-e012b5c59cc7",
             "metadata": {},
             "outputs": [],
@@ -70,7 +70,14 @@
                 "    \"FastKerrEccentricEquatorialFlux\",\n",
                 "    sum_kwargs=dict(pad_output=True, odd_len=True),\n",
                 "    return_list=True,\n",
-                ")"
+                ")\n",
+                "\n",
+                "# Trick to share waveform generator between both few_gen and td_gen (and reduce\n",
+                "# memory consumption)\n",
+                "td_gen.waveform_generator = few_gen.waveform_generator\n",
+                "\n",
+                "import gc\n",
+                "gc.collect()"
             ]
         },
         {
@@ -1258,7 +1265,7 @@
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": "few2.0rc1",
+            "display_name": "few-venv",
             "language": "python",
             "name": "python3"
         },
@@ -1272,7 +1279,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.12.9"
+            "version": "3.12.3"
         }
     },
     "nbformat": 4,

--- a/src/few/amplitude/ampinterp2d.py
+++ b/src/few/amplitude/ampinterp2d.py
@@ -1,21 +1,6 @@
 # Flux-based Schwarzschild Eccentric amplitude module for Fast EMRI Waveforms
 # performs calculation with a Roman network
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 from copy import deepcopy
 import os
 import pathlib

--- a/src/few/amplitude/romannet.py
+++ b/src/few/amplitude/romannet.py
@@ -1,22 +1,6 @@
 # Flux-based Schwarzschild Eccentric amplitude module for Fast EMRI Waveforms
 # performs calculation with a Roman network
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-
 import h5py
 import numpy as np
 from scipy.interpolate import RectBivariateSpline

--- a/src/few/cutils/interpolate.cu
+++ b/src/few/cutils/interpolate.cu
@@ -1,20 +1,5 @@
 // Interpolate and sum modes for an EMRI waveform
 
-// Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 #include "global.h"
 #include "interpolate.hh"
 

--- a/src/few/cutils/matmul.cu
+++ b/src/few/cutils/matmul.cu
@@ -1,20 +1,5 @@
 // Code for matrix operations for roman neural network in Fast EMRI Waveforms
 
-// Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 #include "global.h"
 #include "matmul.hh"
 #include "cuda_complex.hpp"

--- a/src/few/summation/aakwave.py
+++ b/src/few/summation/aakwave.py
@@ -1,20 +1,4 @@
 # AAK summation module for Fast EMRI Waveforms
-#
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 
 import numpy as np
 

--- a/src/few/summation/directmodesum.py
+++ b/src/few/summation/directmodesum.py
@@ -1,20 +1,5 @@
 # Direct summation of modes in python for the FastEMRIWaveforms Package
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 from .base import SummationBase
 
 class DirectModeSum(SummationBase):

--- a/src/few/summation/fdinterp.py
+++ b/src/few/summation/fdinterp.py
@@ -1,20 +1,5 @@
 # Interpolated summation of modes in python for the FastEMRIWaveforms Package
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 import numpy as np
 
 # Cython imports

--- a/src/few/summation/interpolatedmodesum.py
+++ b/src/few/summation/interpolatedmodesum.py
@@ -1,20 +1,5 @@
 # Interpolated summation of modes in python for the FastEMRIWaveforms Package
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 import numpy as np
 
 # Python imports

--- a/src/few/trajectory/inspiral.py
+++ b/src/few/trajectory/inspiral.py
@@ -1,23 +1,5 @@
 # Pn5-based Generic Kerr trajectory module for Fast EMRI Waveforms
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-# Based on implementation from Fujita & Shibata 2020
-# See specific code documentation for proper citation.
-
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-
 import numpy as np
 
 # Python imports

--- a/src/few/trajectory/integrate.py
+++ b/src/few/trajectory/integrate.py
@@ -1,22 +1,5 @@
 # Pn5-based Generic Kerr trajectory module for Fast EMRI Waveforms
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-# Based on implementation from Fujita & Shibata 2020
-# See specific code documentation for proper citation.
-
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 from __future__ import annotations
 
 from typing import Optional, Tuple, Type

--- a/src/few/utils/baseclasses.py
+++ b/src/few/utils/baseclasses.py
@@ -1,20 +1,5 @@
 # Collection of base classes for FastEMRIWaveforms Packages
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 """
 The :code:`few.utils.baseclasses` module contains abstract base classes for the
 various modules. When creating new modules, these classes should be used to maintain

--- a/src/few/utils/citations.py
+++ b/src/few/utils/citations.py
@@ -1,20 +1,5 @@
 # Collection of citations for modules in FastEMRIWaveforms package
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 """
 :code:`few.utils.citations`:
 

--- a/src/few/utils/fdutils.py
+++ b/src/few/utils/fdutils.py
@@ -1,20 +1,5 @@
 # Interpolated summation of modes in python for the FastEMRIWaveforms Package
 
-# Copyright (C) 2023 Michael L. Katz, Lorenzo Speri
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 import numpy as np
 
 from typing import Optional

--- a/src/few/utils/modeselector.py
+++ b/src/few/utils/modeselector.py
@@ -1,21 +1,5 @@
 # Online mode selection for FastEMRIWaveforms Packages
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-
 import numpy as np
 
 import os

--- a/src/few/utils/utility.py
+++ b/src/few/utils/utility.py
@@ -1,21 +1,5 @@
 # Utilities to aid in FastEMRIWaveforms Packages
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-
 import numpy as np
 from scipy.optimize import brentq
 

--- a/src/few/utils/ylm.py
+++ b/src/few/utils/ylm.py
@@ -1,20 +1,5 @@
 # Function for ylm generation for FastEMRIWaveforms Packages
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 import numpy as np
 
 # base classes

--- a/src/few/waveform/waveform.py
+++ b/src/few/waveform/waveform.py
@@ -1,20 +1,5 @@
 # Main waveform class location
 
-# Copyright (C) 2020 Michael L. Katz, Alvin J.K. Chua, Niels Warburton, Scott A. Hughes
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 import os
 
 import numpy as np


### PR DESCRIPTION
This PR does the following:

- [x] Fix the wheel build process (some wheels were not always built with the expected name and/or version)
- [x] Fix the documentation build process
  - Some links were dead
  - The documentation referenced the `few.utils.pn_map` which is now `few.utils.mappings.pn`
  - I re-enabled computing the whole tutorial notebooks when publishing documentation on GitHub pages (this is not enabled on ReadTheDocs due to too limited memory constraints)
- [x] Removed the GPL license header from some source files where it was still present

I also checked that macOS and CC-IN2P3 installation instructions are still up-to-date.


